### PR TITLE
Issue 11: Allow blank Watch Namespace

### DIFF
--- a/cmd/zookeeper-operator/main.go
+++ b/cmd/zookeeper-operator/main.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"runtime"
 
-	sdk "github.com/operator-framework/operator-sdk/pkg/sdk"
-	k8sutil "github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
+	"github.com/operator-framework/operator-sdk/pkg/sdk"
+	"github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
-	stub "github.com/pravega/zookeeper-operator/pkg/stub"
+	"github.com/pravega/zookeeper-operator/pkg/stub"
 
-	"fmt"
 	"github.com/sirupsen/logrus"
 	"os"
 )
@@ -25,10 +24,7 @@ func main() {
 
 	resource := "zookeeper.pravega.io/v1beta1"
 	kind := "ZookeeperCluster"
-	namespace, err := getWatchNamespaceAllowBlank()
-	if err != nil {
-		logrus.Fatalf("Failed to get watch namespace: %v", err)
-	}
+	namespace := getWatchNamespaceAllowBlank()
 	resyncPeriod := 5
 	logrus.Infof("Watching %s, %s, %s, %d", resource, kind, namespace, resyncPeriod)
 	sdk.Watch(resource, kind, namespace, resyncPeriod)
@@ -37,10 +33,11 @@ func main() {
 }
 
 // GetWatchNamespaceAllowBlank returns the namespace the operator should be watching for changes
-func getWatchNamespaceAllowBlank() (string, error) {
+func getWatchNamespaceAllowBlank() string {
 	ns, found := os.LookupEnv(k8sutil.WatchNamespaceEnvVar)
 	if !found {
-		return "", fmt.Errorf("%s must be set", k8sutil.WatchNamespaceEnvVar)
+		logrus.Infof("%s is not set, watching all namespaces", k8sutil.WatchNamespaceEnvVar)
+		ns = ""
 	}
-	return ns, nil
+	return ns
 }


### PR DESCRIPTION
This uses a custom function to get the Watch Namespace allowing "watch all namespaces".  The SDK `GetWatchNamespace` function currently does not allow a blank namespace