### PR TITLE
[issue-21] Add versioning

### DIFF
--- a/cmd/zookeeper-operator/main.go
+++ b/cmd/zookeeper-operator/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"flag"
+	"fmt"
 	"runtime"
 	"time"
 
@@ -9,19 +11,35 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/pravega/zookeeper-operator/pkg/stub"
+	"github.com/pravega/zookeeper-operator/pkg/version"
+
+	"os"
 
 	"github.com/sirupsen/logrus"
-	"os"
 )
 
-func printVersion() {
-	logrus.Infof("Go Version: %s", runtime.Version())
-	logrus.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
-	logrus.Infof("operator-sdk Version: %v", sdkVersion.Version)
+var (
+	printVersion bool
+)
+
+func init() {
+	flag.BoolVar(&printVersion, "version", false, "Show version and quit")
+	flag.Parse()
 }
 
 func main() {
-	printVersion()
+	if printVersion {
+		fmt.Println("zookeeper-operator Version:", version.Version)
+		fmt.Println("Go Version:", runtime.Version())
+		fmt.Printf("Go OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+		fmt.Printf("operator-sdk Version: %v", sdkVersion.Version)
+		os.Exit(0)
+	}
+
+	logrus.Infof("zookeeper-operator Version: %v", version.Version)
+	logrus.Infof("Go Version: %s", runtime.Version())
+	logrus.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
+	logrus.Infof("operator-sdk Version: %v", sdkVersion.Version)
 
 	resource := "zookeeper.pravega.io/v1beta1"
 	kind := "ZookeeperCluster"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,5 @@
+package version
+
+var (
+	Version = "master"
+)


### PR DESCRIPTION
- Fix #21
- Add version package under `pkg/version` with inital `master` version as we haven't made any released yet. We will replace it with the version number before a release.
- Add `-version` flag to show version and quit