### PR TITLE
Fixup AccessMode in example/cr-detailed.yaml

### DIFF
--- a/example/cr-detailed.yaml
+++ b/example/cr-detailed.yaml
@@ -44,7 +44,7 @@ spec:
     securityContext: {}
   persistence:
     accessModes:
-    - RWO
+    - ReadWriteOnce
     resources:
       requests:
         storage: 20Gi


### PR DESCRIPTION
Mundane change.

I was using example/cr-detailed.yaml and it did not work. Found that the issue was that the sample value for spec.persistence.accessModes is incorrect.