### PR TITLE
Flag to print operator version and commit SHA

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -23,6 +23,7 @@ import (
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/pravega/zookeeper-operator/pkg/apis"
 	"github.com/pravega/zookeeper-operator/pkg/controller"
+	"github.com/pravega/zookeeper-operator/pkg/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -30,9 +31,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
-var log = logf.Log.WithName("cmd")
+var (
+	log         = logf.Log.WithName("cmd")
+	versionFlag bool
+)
+
+func init() {
+	flag.BoolVar(&versionFlag, "version", false, "Show version and quit")
+}
 
 func printVersion() {
+	log.Info(fmt.Sprintf("zookeeper-operator Version: %v", version.Version))
+	log.Info(fmt.Sprintf("Git SHA: %s", version.GitSHA))
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
@@ -48,6 +58,10 @@ func main() {
 	logf.SetLogger(logf.ZapLogger(false))
 
 	printVersion()
+
+	if versionFlag {
+		os.Exit(0)
+	}
 
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -10,6 +10,8 @@
 
 package version
 
-var (
-	Version = "0.0.1"
-)
+// Version represents the software version of the Zookeeper Operator
+var Version string
+
+// GitSHA represents the Git commit hash in short format
+var GitSHA string


### PR DESCRIPTION
### Change log description
- Add a new flag `-version` to print the version and commit SHA and exit
- Move `version.go` under `pkg/` to match the "ldflags" in the Makefile

### Purpose of the change
Fix #47  

### How to test the change

```
$ make build-go
$ bin/zookeeper-operator -version 
{"level":"info","ts":1548236354.4415796,"logger":"cmd","msg":"zookeeper-operator Version: 0.2.0-1"}
{"level":"info","ts":1548236354.4416833,"logger":"cmd","msg":"Git SHA: 719a0dd"}
...
```

---
Signed-off-by: Adrián Moreno <adrian@morenomartinez.com>