### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@
 package version
 
 // Version represents the software version of the Zookeeper Operator
-var Version string
+var Version = "0.2.1"
 
 // GitSHA represents the Git commit hash in short format
 var GitSHA string


### PR DESCRIPTION
We'd like to bump the version to `0.2.1` to release binaries for the latest YAML export feature, which uses the Zookeeper Operator to output YAML files of any secondary resources that _would_ be created by the operator, if it were running.