### PR TITLE
[FABRIC-7605] exporter binary for windows was missing .exe extention …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ deploy:
     file:
       - bin/zookeeper-exporter-linux-amd64
       - bin/zookeeper-exporter-darwin-amd64
-      - bin/zookeeper-exporter-windows-amd64
+      - bin/zookeeper-exporter-windows-amd64.exe
     skip_cleanup: true
     on:
       branch: master


### PR DESCRIPTION
…in .travis.yml