### PR TITLE
Update to support dynamic zookeeper naming

### DIFF
--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -93,7 +93,7 @@ func (s *ZookeeperClusterSpec) withDefaults(z *ZookeeperCluster) (changed bool) 
 		s.Ports = []v1.ContainerPort{
 			{
 				Name:          "client",
-				ContainerPort: 2181,
+				ContainerPort: 9277,
 			},
 			{
 				Name:          "quorum",

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -238,7 +238,7 @@ func makeService(name string, ports []v1.ServicePort, clusterIP bool, z *v1beta1
 					Kind:    "ZookeeperCluster",
 				}),
 			},
-			Labels: map[string]string{"app": z.GetName()},
+			Labels: map[string]string{"app": name},
 		},
 		Spec: v1.ServiceSpec{
 			Ports:    ports,


### PR DESCRIPTION
This change enables the cluster to use the zookeeper-client directly
instead of having to duplicate the service.

Signed-off-by: Tudor Marcu <Tudor.Marcu@emc.com>