### PR TITLE
Issue 63: Enabling ephemeral storage for zookeeper.

### DIFF
--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -67,8 +67,8 @@ type ZookeeperClusterSpec struct {
 
 	// Persistence is the configuration for zookeeper persistent layer.
 	// PersistentVolumeClaimSpec and VolumeReclaimPolicy can be specified in here.
-    // This field is optional. If no persistence is provided, stateful containers will use
-    // emptyDir as volume.
+	// This field is optional. If no persistence is provided, stateful containers will use
+	// emptyDir as volume.
 	Persistence *Persistence `json:"persistence,omitempty"`
 
 	// Conf is the zookeeper configuration, which will be used to generate the

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -67,6 +67,8 @@ type ZookeeperClusterSpec struct {
 
 	// Persistence is the configuration for zookeeper persistent layer.
 	// PersistentVolumeClaimSpec and VolumeReclaimPolicy can be specified in here.
+    // This field is optional. If no persistence is provided, stateful containers will use
+    // emptyDir as volume.
 	Persistence *Persistence `json:"persistence,omitempty"`
 
 	// Conf is the zookeeper configuration, which will be used to generate the
@@ -120,13 +122,11 @@ func (s *ZookeeperClusterSpec) withDefaults(z *ZookeeperCluster) (changed bool) 
 	if s.Pod.withDefaults(z) {
 		changed = true
 	}
-	if s.Persistence == nil {
-		s.Persistence = &Persistence{}
+
+	if s.Persistence != nil && s.Persistence.withDefaults() {
 		changed = true
 	}
-	if s.Persistence.withDefaults() {
-		changed = true
-	}
+
 	return changed
 }
 
@@ -366,8 +366,6 @@ type Persistence struct {
 	// The default value is Retain.
 	VolumeReclaimPolicy VolumeReclaimPolicy `json:"reclaimPolicy,omitempty"`
 	// PersistentVolumeClaimSpec is the spec to describe PVC for the container
-	// This field is optional. If no PVC spec, stateful containers will use
-	// emptyDir as volume.
 	PersistentVolumeClaimSpec v1.PersistentVolumeClaimSpec `json:"spec,omitempty"`
 }
 

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types_test.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types_test.go
@@ -36,6 +36,9 @@ var _ = Describe("ZookeeperCluster Types", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "example",
 			},
+			Spec: v1beta1.ZookeeperClusterSpec{
+				Persistence: &v1beta1.Persistence{},
+			},
 		}
 	})
 

--- a/pkg/controller/zookeepercluster/zookeepercluster_controller.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller.go
@@ -467,7 +467,7 @@ func (r *ReconcileZookeeperCluster) yamlConfigMap(instance *zookeeperv1beta1.Zoo
 }
 
 func (r *ReconcileZookeeperCluster) reconcileFinalizers(instance *zookeeperv1beta1.ZookeeperCluster) (err error) {
-	if instance.Spec.Persistence.VolumeReclaimPolicy != zookeeperv1beta1.VolumeReclaimPolicyDelete {
+	if instance.Spec.Persistence != nil && instance.Spec.Persistence.VolumeReclaimPolicy != zookeeperv1beta1.VolumeReclaimPolicyDelete {
 		return nil
 	}
 	if instance.DeletionTimestamp.IsZero() {

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -146,13 +146,13 @@ func makeZkPodSpec(z *v1beta1.ZookeeperCluster, volumes []v1.Volume) v1.PodSpec 
 		Containers: []v1.Container{zkContainer},
 		Affinity:   z.Spec.Pod.Affinity,
 		Volumes:    volumes,
-		TerminationGracePeriodSeconds: &z.Spec.Pod.TerminationGracePeriodSeconds,
 	}
 	if reflect.DeepEqual(v1.PodSecurityContext{}, z.Spec.Pod.SecurityContext) {
 		podSpec.SecurityContext = z.Spec.Pod.SecurityContext
 	}
 	podSpec.NodeSelector = z.Spec.Pod.NodeSelector
 	podSpec.Tolerations = z.Spec.Pod.Tolerations
+	podSpec.TerminationGracePeriodSeconds = &z.Spec.Pod.TerminationGracePeriodSeconds
 
 	return podSpec
 }

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -32,8 +32,30 @@ func headlessSvcName(z *v1beta1.ZookeeperCluster) string {
 	return fmt.Sprintf("%s-headless", z.GetName())
 }
 
+var zkDataVolume = "data"
+
 // MakeStatefulSet return a zookeeper stateful set from the zk spec
 func MakeStatefulSet(z *v1beta1.ZookeeperCluster) *appsv1.StatefulSet {
+	extraVolumes := []v1.Volume{}
+	persistence := z.Spec.Persistence
+	pvcs := []v1.PersistentVolumeClaim{}
+	if persistence != nil {
+		pvcs = append(pvcs, v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   zkDataVolume,
+				Labels: map[string]string{"app": z.GetName()},
+			},
+			Spec: persistence.PersistentVolumeClaimSpec,
+		})
+	} else {
+		extraVolumes = append(extraVolumes, v1.Volume{
+			Name: zkDataVolume,
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{},
+			},
+		})
+	}
+
 	return &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StatefulSet",
@@ -64,22 +86,14 @@ func MakeStatefulSet(z *v1beta1.ZookeeperCluster) *appsv1.StatefulSet {
 						"kind": "ZookeeperMember",
 					},
 				},
-				Spec: makeZkPodSpec(z),
+				Spec: makeZkPodSpec(z, extraVolumes),
 			},
-			VolumeClaimTemplates: []v1.PersistentVolumeClaim{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "data",
-						Labels: map[string]string{"app": z.GetName()},
-					},
-					Spec: z.Spec.Persistence.PersistentVolumeClaimSpec,
-				},
-			},
+			VolumeClaimTemplates: pvcs,
 		},
 	}
 }
 
-func makeZkPodSpec(z *v1beta1.ZookeeperCluster) v1.PodSpec {
+func makeZkPodSpec(z *v1beta1.ZookeeperCluster, volumes []v1.Volume) v1.PodSpec {
 	zkContainer := v1.Container{
 		Name:            "zookeeper",
 		Image:           z.Spec.Image.ToString(),
@@ -115,22 +129,23 @@ func makeZkPodSpec(z *v1beta1.ZookeeperCluster) v1.PodSpec {
 	if z.Spec.Pod.Resources.Limits != nil || z.Spec.Pod.Resources.Requests != nil {
 		zkContainer.Resources = z.Spec.Pod.Resources
 	}
+
+	volumes = append(volumes, v1.Volume{
+		Name: "conf",
+		VolumeSource: v1.VolumeSource{
+			ConfigMap: &v1.ConfigMapVolumeSource{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: z.ConfigMapName(),
+				},
+			},
+		},
+	})
+
 	zkContainer.Env = z.Spec.Pod.Env
 	podSpec := v1.PodSpec{
 		Containers: []v1.Container{zkContainer},
 		Affinity:   z.Spec.Pod.Affinity,
-		Volumes: []v1.Volume{
-			{
-				Name: "conf",
-				VolumeSource: v1.VolumeSource{
-					ConfigMap: &v1.ConfigMapVolumeSource{
-						LocalObjectReference: v1.LocalObjectReference{
-							Name: z.ConfigMapName(),
-						},
-					},
-				},
-			},
-		},
+		Volumes:    volumes,
 		TerminationGracePeriodSeconds: &z.Spec.Pod.TerminationGracePeriodSeconds,
 	}
 	if reflect.DeepEqual(v1.PodSecurityContext{}, z.Spec.Pod.SecurityContext) {

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -11,6 +11,11 @@ invalidFiles=$(gofmt -l $goFiles)
 
 if [ "$invalidFiles" ]; then
   echo -e "These files did not pass the 'go fmt' check, please run 'go fmt' on them:"
-  echo -e $invalidFiles
+  for file in $invalidFiles
+  do
+    echo ""
+    gofmt -d $file
+  done
+
   exit 1
 fi


### PR DESCRIPTION
### Changelog Description

This PR allows users to create zookeepers with ephemeral storage instead of PVCs.

To enable ephemeral storage, omit 
```
spec:
    persistence
````

This change breaks backwards compatibility, but it does adhere to the documentation of the Zookeeper CRD: https://github.com/pravega/zookeeper-operator/blob/68336c7f9fcd51437ec1cfd3fcac40d172610938/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go#L68-L71

### Purpose of the change

Fix #63 

### How to verify

Start the operator, create a Zk cluster without persistence. 

Signed-off-by: Houston Putman <hputman1@bloomberg.net>