### PR TITLE
Issue 66: Make zoo.cfg writable

### DIFF
--- a/docker/bin/zookeeperReady.sh
+++ b/docker/bin/zookeeperReady.sh
@@ -15,7 +15,8 @@ source /conf/env.sh
 source /usr/local/bin/zookeeperFunctions.sh
 
 HOST=`hostname -s`
-DATA_DIR=/data
+ZKROOT=/zookeeper
+DATA_DIR=$ZKROOT/data
 MYID_FILE=$DATA_DIR/myid
 LOG4J_CONF=/conf/log4j-quiet.properties
 

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -15,10 +15,11 @@ source /conf/env.sh
 source /usr/local/bin/zookeeperFunctions.sh
 
 HOST=`hostname -s`
-DATA_DIR=/data
+ZKROOT=/zookeeper
+DATA_DIR=$ZKROOT/data
 MYID_FILE=$DATA_DIR/myid
 LOG4J_CONF=/conf/log4j-quiet.properties
-ZOOCFGDIR=$DATA_DIR/conf
+ZOOCFGDIR=$ZKROOT/conf
 DYNCONFIG=$DATA_DIR/zoo.cfg.dynamic
 
 # Copy over the zoo.cfg file in the configmap to make it writable

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -20,6 +20,10 @@ MYID_FILE=$DATA_DIR/myid
 LOG4J_CONF=/conf/log4j-quiet.properties
 DYNCONFIG=$DATA_DIR/zoo.cfg.dynamic
 
+# Copy over the zoo.cfg file in the configmap to make it writable
+ZOOCFGDIR=$DATA_DIR
+cp /conf/zoo.cfg /data/zoo.cfg
+
 # Extract resource name and this members ordinal value from pod hostname
 if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
     NAME=${BASH_REMATCH[1]}

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -18,11 +18,16 @@ HOST=`hostname -s`
 DATA_DIR=/data
 MYID_FILE=$DATA_DIR/myid
 LOG4J_CONF=/conf/log4j-quiet.properties
+ZOOCFGDIR=$DATA_DIR/conf
 DYNCONFIG=$DATA_DIR/zoo.cfg.dynamic
 
 # Copy over the zoo.cfg file in the configmap to make it writable
-ZOOCFGDIR=$DATA_DIR
-cp /conf/zoo.cfg /data/zoo.cfg
+if [ -d $ZOOCFGDIR ]; then
+  rm -r $ZOOCFGDIR
+fi
+mkdir $ZOOCFGDIR
+cp /conf/zoo.cfg $ZOOCFGDIR
+cp /conf/log4j.properties $ZOOCFGDIR
 
 # Extract resource name and this members ordinal value from pod hostname
 if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then

--- a/docker/bin/zookeeperTeardown.sh
+++ b/docker/bin/zookeeperTeardown.sh
@@ -14,7 +14,8 @@ set -ex
 source /conf/env.sh
 source /usr/local/bin/zookeeperFunctions.sh
 
-DATA_DIR=/data
+ZKROOT=/zookeeper
+DATA_DIR=$ZKROOT/data
 MYID_FILE=$DATA_DIR/myid
 LOG4J_CONF=/conf/log4j-quiet.properties
 

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -100,7 +100,7 @@ func makeZkPodSpec(z *v1beta1.ZookeeperCluster) v1.PodSpec {
 			},
 		},
 		VolumeMounts: []v1.VolumeMount{
-			{Name: "data", MountPath: "/data"},
+			{Name: "data", MountPath: "/zookeeper/data"},
 			{Name: "conf", MountPath: "/conf"},
 		},
 		Lifecycle: &v1.Lifecycle{
@@ -184,14 +184,14 @@ func MakeHeadlessService(z *v1beta1.ZookeeperCluster) *v1.Service {
 
 func makeZkConfigString(s v1beta1.ZookeeperClusterSpec) string {
 	return "4lw.commands.whitelist=cons, envi, conf, crst, srvr, stat, mntr, ruok\n" +
-		"dataDir=/data\n" +
+		"dataDir=/zookeeper/data\n" +
 		"standaloneEnabled=false\n" +
 		"reconfigEnabled=true\n" +
 		"skipACL=yes\n" +
 		"initLimit=" + strconv.Itoa(s.Conf.InitLimit) + "\n" +
 		"syncLimit=" + strconv.Itoa(s.Conf.SyncLimit) + "\n" +
 		"tickTime=" + strconv.Itoa(s.Conf.TickTime) + "\n" +
-		"dynamicConfigFile=/data/zoo.cfg.dynamic\n"
+		"dynamicConfigFile=/zookeeper/data/zoo.cfg.dynamic\n"
 }
 
 func makeZkLog4JQuietConfigString() string {

--- a/pkg/zk/generators_test.go
+++ b/pkg/zk/generators_test.go
@@ -52,8 +52,8 @@ var _ = Describe("Generators Spec", func() {
 					cfg = cm.Data["zoo.cfg"]
 				})
 
-				It("should have a datadir of '/data'", func() {
-					Ω(cfg).To(ContainSubstring("dataDir=/data\n"))
+				It("should have a datadir of '/zookeeper/data'", func() {
+					Ω(cfg).To(ContainSubstring("dataDir=/zookeeper/data\n"))
 				})
 
 				It("should set standaloneEnabled to 'false'", func() {
@@ -83,7 +83,7 @@ var _ = Describe("Generators Spec", func() {
 				It("should have a dynamicConfigFile", func() {
 					Ω(cfg).
 						To(ContainSubstring(
-							"dynamicConfigFile=/data/zoo.cfg.dynamic\n"))
+							"dynamicConfigFile=/zookeeper/data/zoo.cfg.dynamic\n"))
 				})
 			})
 


### PR DESCRIPTION
### Changelog Description
This PR makes the zoo.cfg writable

### Purpose of the change
Fix #66

### How to verify
Start 2 nodes and log into them, check the `zoo.cfg` file in the `/data/conf` dir to see if it contains the latest  `zoo.cfg.dynamic` file and check  `zoo.cfg.dynamic` to see if they have the latest info. 


Signed-off-by: wenqimou <452787782@qq.com>