### PR TITLE
Issue 72: Reduce Pod recovery time

### DIFF
--- a/docker/zu/src/main/java/io/pravega/zookeeper/Zookeeper.kt
+++ b/docker/zu/src/main/java/io/pravega/zookeeper/Zookeeper.kt
@@ -17,7 +17,7 @@ import org.apache.zookeeper.admin.ZooKeeperAdmin
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
-const val ZK_CONNECTION_TIMEOUT_MINS: Long  = 10
+const val ZK_CONNECTION_TIMEOUT_MINS: Long  = 1
 
 /**
  * Creates a new Zookeeper client and waits until it's in a connected state


### PR DESCRIPTION
### Change log description
Reduce the timeout waiting for the [`Future`](https://github.com/pravega/zookeeper-operator/blob/88748261ed286f75b043740217ed2e03942f7eac/docker/zu/src/main/java/io/pravega/zookeeper/Zookeeper.kt#L62) to get a result from zk-client. When timeout fires the zk pod will crash and restart to try to connect again. In our experiments, this method can reduce the waiting time. 

### Purpose of the change
Fix #72 

### How to verify it
Create a zk cluster of size 5 in PKS, delete 2 of them forcefully and see how long do these two pods come back up. 

Signed-off-by: wenqimou <452787782@qq.com>