### PR TITLE
Issue 80: Adding Helm Charts for Zookeper deployment and testing

### DIFF
--- a/charts/zookeeper-operator/Chart.yaml
+++ b/charts/zookeeper-operator/Chart.yaml
@@ -1,0 +1,12 @@
+name: zookeeper-operator
+version: 0.2.2
+appVersion: 0.2.2
+description: zookeeper operator Helm chart for Kubernetes
+keywords:
+- zookeeper
+- storage
+home: https://github.com/pravega/charts/blob/master/zookeeper-operator
+icon: https://zookeeper.apache.org/images/zookeeper_small.gif
+sources:
+- https://github.com/pravega/charts/blob/master/zookeeper-operator
+engine: gotpl

--- a/charts/zookeeper-operator/Chart.yaml
+++ b/charts/zookeeper-operator/Chart.yaml
@@ -5,8 +5,8 @@ description: zookeeper operator Helm chart for Kubernetes
 keywords:
 - zookeeper
 - storage
-home: https://github.com/pravega/charts/blob/master/zookeeper-operator
+home: https://github.com/pravega/zookeeper-operator/blob/master/charts/zookeeper-operator
 icon: https://zookeeper.apache.org/images/zookeeper_small.gif
 sources:
-- https://github.com/pravega/charts/blob/master/zookeeper-operator
+- https://github.com/pravega/zookeeper-operator/blob/master/charts/zookeeper-operator
 engine: gotpl

--- a/charts/zookeeper-operator/templates/_helpers.tpl
+++ b/charts/zookeeper-operator/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "zookeeper-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "zookeeper-operator.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/zookeeper-operator/templates/clusterrole.yaml
+++ b/charts/zookeeper-operator/templates/clusterrole.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "zookeeper-operator.fullname" . }}
+rules:
+- apiGroups:
+  - zookeeper.pravega.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - "*"
+  verbs:
+  - '*'
+{{- end }}

--- a/charts/zookeeper-operator/templates/clusterrolebinding.yaml
+++ b/charts/zookeeper-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "zookeeper-operator.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "zookeeper-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/zookeeper-operator/templates/crd.yaml
+++ b/charts/zookeeper-operator/templates/crd.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.crd.create }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: zookeeperclusters.zookeeper.pravega.io
+spec:
+  group: zookeeper.pravega.io
+  names:
+    kind: ZookeeperCluster
+    listKind: ZookeeperClusterList
+    plural: zookeeperclusters
+    singular: zookeepercluster
+    shortNames:
+    - zk
+  additionalPrinterColumns:
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  scope: Namespaced
+  version: v1beta1
+  subresources:
+    status: {}
+{{- end }}

--- a/charts/zookeeper-operator/templates/operator.yaml
+++ b/charts/zookeeper-operator/templates/operator.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "zookeeper-operator.fullname" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ template "zookeeper-operator.fullname" . }}
+  template:
+    metadata:
+      labels:
+        name: {{ template "zookeeper-operator.fullname" . }}
+        component: zookeeper-operator
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      containers:
+      - name: {{ template "zookeeper-operator.fullname" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 6000
+          name: metrics
+        command:
+        - zookeeper-operator
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: {{ template "zookeeper-operator.fullname" . }}

--- a/charts/zookeeper-operator/templates/role.yaml
+++ b/charts/zookeeper-operator/templates/role.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.rbac.create }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "zookeeper-operator.fullname" . }}
+rules:
+- apiGroups:
+  - zookeeper.pravega.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - "*"
+{{- end }}
+

--- a/charts/zookeeper-operator/templates/rolebinding.yaml
+++ b/charts/zookeeper-operator/templates/rolebinding.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.rbac.create }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "zookeeper-operator.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+roleRef:
+  kind: Role
+  name: {{ template "zookeeper-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/zookeeper-operator/templates/service_account.yaml
+++ b/charts/zookeeper-operator/templates/service_account.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+{{- end }}

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -1,0 +1,21 @@
+# Default values for zookeeper-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: pravega/zookeeper-operator
+  tag: 0.2.2
+  pullPolicy: IfNotPresent
+
+## Install RBAC roles and bindings
+rbac:
+  create: true
+
+## Service account names and whether to create them
+serviceAccount:
+  create: true
+  name: zookeeper-operator
+
+# Whether to create custom resource
+crd:
+  create: true

--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -1,0 +1,12 @@
+name: zookeeper
+version: 0.2.2
+appVersion: 0.2.2
+description: zookeeper Helm chart for Kubernetes
+keywords:
+- zookeeper
+- storage
+home: https://github.com/pravega/zookeeper
+icon: https://avatars3.githubusercontent.com/u/25698199
+sources:
+- https://github.com/pravega/zookeeper
+engine: gotpl

--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -5,8 +5,8 @@ description: zookeeper Helm chart for Kubernetes
 keywords:
 - zookeeper
 - storage
-home: https://github.com/pravega/zookeeper
-icon: https://avatars3.githubusercontent.com/u/25698199
+home: https://github.com/pravega/zookeeper-operator/blob/master/charts/zookeeper
+icon: https://zookeeper.apache.org/images/zookeeper_small.gif
 sources:
-- https://github.com/pravega/zookeeper
+- https://github.com/apache/zookeeper
 engine: gotpl

--- a/charts/zookeeper/templates/_helpers.tpl
+++ b/charts/zookeeper/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "zookeeper.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "zookeeper.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/zookeeper/templates/tests/clusterrole.yaml
+++ b/charts/zookeeper/templates/tests/clusterrole.yaml
@@ -1,0 +1,11 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "{{.Release.Name}}-zookeeper-test"
+rules:
+- apiGroups:
+  - zookeeper.pravega.io
+  resources:
+  - "*"
+  verbs:
+  - get

--- a/charts/zookeeper/templates/tests/clusterrolebinding.yaml
+++ b/charts/zookeeper/templates/tests/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "{{.Release.Name}}-zookeeper-test"
+subjects:
+- kind: ServiceAccount
+  name: "{{.Release.Name}}-zookeeper-test"
+  namespace: "{{.Release.Namespace}}"
+roleRef:
+  kind: ClusterRole
+  name: "{{.Release.Name}}-zookeeper-test"
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/zookeeper/templates/tests/service_account.yaml
+++ b/charts/zookeeper/templates/tests/service_account.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{.Release.Name}}-zookeeper-test"
+  annotations:
+    nautilus.dellemc.com/serviceaccount-secret-name: zookeeper
+  labels:
+    app.kubernetes.io/name: zookeeper
+    app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/charts/zookeeper/templates/tests/test.yaml
+++ b/charts/zookeeper/templates/tests/test.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata: 
+  name: "{{ .Release.Name }}-zookeeper-test"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  serviceAccountName: "{{.Release.Name}}-zookeeper-test"
+  containers:
+  - name: {{ .Release.Name }}-zookeeper-test
+    image: lachlanevenson/k8s-kubectl:v1.14.6
+    imagePullPolicy: "IfNotPresent"
+    command: ["sh", "-c"]
+    args:
+    -  kubectl get zk -n {{ .Release.Namespace }} {{ template "zookeeper.fullname" . }} -o jsonpath='{.status.members.unready}' | grep nil ;
+  restartPolicy: Never

--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -1,0 +1,6 @@
+apiVersion: "zookeeper.pravega.io/v1beta1"
+kind: "ZookeeperCluster"
+metadata:
+  name: {{ template "zookeeper.fullname" . }}
+spec:
+  size: 3

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -1,0 +1,4 @@
+image:
+  repository: pravega/zookeeper
+  tag: 0.2.2
+  pullPolicy: IfNotPresent


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
- Adding helm chart to deploy zookeeper-operator and zookeeper into Kubernetes cluster
- Implementing helm test to test successful deployment/upgrade of zookeeper cluster 

### Purpose of the change
Fixes #80 

### How to verify it
To deploy zookeper operator
`helm install charts/zookeeper-operator --name <zk-operator-release-name>`

To deploy zookeper cluster
`helm install charts/zookeeper --name <zk-release-name>`

To test the zookeeper cluster deployment/upgrade
`helm test <zk-release-name>`

If the zookeeper deployment/upgrade was successful and all pods are in Ready state then the test should pass, else it should fail.