### PR TITLE
Issue 82: Upgrading zookeeper image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,10 @@ COPY zu /zu
 WORKDIR /zu
 RUN ./gradlew assemble
 
-FROM zookeeper:3.5.4-beta
+FROM zookeeper:3.5.5
 COPY bin /usr/local/bin
 RUN chmod +x /usr/local/bin/*
 COPY --from=0 /zu/build/libs/zu.jar /root/
+
+RUN apt-get -q update && \
+    apt-get install -y dnsutils


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Upgrates the Zookeeper image from 3.5.4-beta to 3.5.5

### Purpose of the change
Fixes #82 

### How to verify it
Ran the following tests successfully to validate that upgrading to the new image is compatible
- System Tests
- Longevity Tests
- Pravega Benchmark (ensured that we face no performance issues with the new image)