### PR TITLE
Issue 85: Setting appropriate default zookeeper image

### DIFF
--- a/docker/zu/build.gradle
+++ b/docker/zu/build.gradle
@@ -1,4 +1,4 @@
-ext.zookeeper_version = '3.5.4-beta'
+ext.zookeeper_version = '3.5.5'
 ext.kotlin_version = '1.2.51'
 
 buildscript {

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -21,11 +21,11 @@ import (
 const (
 	// DefaultZkContainerRepository is the default docker repo for the zookeeper
 	// container
-	DefaultZkContainerRepository = "emccorp/zookeeper"
+	DefaultZkContainerRepository = "pravega/zookeeper"
 
 	// DefaultZkContainerVersion is the default tag used for for the zookeeper
 	// container
-	DefaultZkContainerVersion = "3.5.4-beta-operator"
+	DefaultZkContainerVersion = "0.2.3"
 
 	// DefaultZkContainerPolicy is the default container pull policy used
 	DefaultZkContainerPolicy = "Always"


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Changes the default image used to deploy zookeeper from `emccorp/zookeeper:3.5.4-beta-operator` to `pravega/zookeeper:0.2.3`

### Purpose of the change
Fixes #85 

### How to verify it
Deploy zookeeper in a cluster without specifying any image field in the manifest file.  When you describe the zookeeper pod, you should get the following value for the image field :

```
Containers:
  zookeeper:
    Container ID:  docker://9a5e0f63fb4d73ca617c884b50d6cce7dbd87b63234dceeabb7621e59dc8655f
    Image:         pravega/zookeeper:0.2.3
```