### PR TITLE
Issue-89: Fix windows cross compile error and zk default image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- '1.10'
+- '1.12'
 - tip
 sudo: required
 env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.1-alpine3.7 as go-builder
+FROM golang:1.12.10-alpine3.10 as go-builder
 
 ARG PROJECT_NAME=zookeeper-operator
 ARG REPO_PATH=github.com/pravega/$PROJECT_NAME

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ $ kubectl delete -f deploy/all_ns
 ### Build the operator image
 
 Requirements:
-  - Go 1.10+
+  - Go 1.12+
 
 Use the `make` command to build the Zookeeper operator image.
 
@@ -157,7 +157,7 @@ REPOSITORY                    TAG              IMAGE ID        CREATED         S
 
 pravega/zookeeper-operator    0.1.1-3-dirty    2b2d5bcbedf5    10 minutes ago  41.7MB
 
-pravega/zookeeper-operator    latest           2b2d5bcbedf5    10 minutes ago  41.7MB 
+pravega/zookeeper-operator    latest           2b2d5bcbedf5    10 minutes ago  41.7MB
 
 ```
 Optionally push it to a Docker registry.

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -13,7 +13,7 @@ package v1beta1
 import (
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -25,7 +25,7 @@ const (
 
 	// DefaultZkContainerVersion is the default tag used for for the zookeeper
 	// container
-	DefaultZkContainerVersion = "0.2.3"
+	DefaultZkContainerVersion = "latest"
 
 	// DefaultZkContainerPolicy is the default container pull policy used
 	DefaultZkContainerPolicy = "Always"


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

Fixes #89  

Fix to change default zookeeper image deployed by zookeeper-operator to pravega/zookeeper:latest.
Updated go version for buidling zookeeper-operator to 1.12 in travis.yml
Updated go version in base image to 1.12.10 and also updated the Readme to reflect this.
The go version upgrade was needed to resolve a Windows cross compilation failure seen since last 2 days due to external changes to golang libraries.
