### PR TITLE
Issue 92: Zookeeper pods fail to restart when quorum not available

### DIFF
--- a/docker/bin/zookeeperReady.sh
+++ b/docker/bin/zookeeperReady.sh
@@ -54,15 +54,20 @@ if [[ "$OK" == "imok" ]]; then
           ONDISK_CONFIG=true
           DYN_CFG_FILE_LINE=`cat $STATIC_CONFIG|grep "dynamicConfigFile\="`
           DYN_CFG_FILE=${DYN_CFG_FILE_LINE##dynamicConfigFile=}
-          SERVER_LINE=`cat $DYN_CFG_FILE | grep "server.${MYID}="`
-          if [[ $SERVER_LINE == *"participant"* ]]; then
+          SERVER_FOUND=`cat $DYN_CFG_FILE | grep "server.${MYID}=" | wc -l`
+          if [[ "$SERVER_FOUND" == "0" ]]; then
+            echo "Server not found in ensemble. Exiting ..."
+            exit 0
+          fi
+          SERVER=`cat $DYN_CFG_FILE | grep "server.${MYID}="`
+          if [[ $SERVER == *"participant"* ]]; then
               ROLE=participant
           else
               ROLE=observer
           fi
       fi
     fi
-    
+
     if [[ "$ROLE" == "participant" ]]; then
       echo "Zookeeper service is available and an active participant"
     exit 0

--- a/docker/bin/zookeeperReady.sh
+++ b/docker/bin/zookeeperReady.sh
@@ -24,7 +24,6 @@ OK=$(echo ruok | nc 127.0.0.1 $CLIENT_PORT)
 
 # Check to see if zookeeper service answers
 if [[ "$OK" == "imok" ]]; then
-
   set +e
   nslookup $DOMAIN
   if [[ $? -eq 1 ]]; then
@@ -36,7 +35,7 @@ if [[ "$OK" == "imok" ]]; then
     # An ensemble exists, check to see if this node is already a member.
     # Check to see if zookeeper service for this node is a participant
     set +e
-    # Extract resource name and this members ordinal value from pod hostname
+    # Extract resource name and this members' ordinal value from pod hostname
     HOST=`hostname -s`
     if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
         NAME=${BASH_REMATCH[1]}
@@ -50,19 +49,19 @@ if [[ "$OK" == "imok" ]]; then
     if [ -f $MYID_FILE ]; then
       EXISTING_ID="`cat $DATA_DIR/myid`"
       if [[ "$EXISTING_ID" == "$MYID" && -f $STATIC_CONFIG ]]; then
-        # If Id is correct and configuration is present under `/data/conf`
+      #If Id is correct and configuration is present under `/data/conf`
           ONDISK_CONFIG=true
           DYN_CFG_FILE_LINE=`cat $STATIC_CONFIG|grep "dynamicConfigFile\="`
           DYN_CFG_FILE=${DYN_CFG_FILE_LINE##dynamicConfigFile=}
           SERVER_FOUND=`cat $DYN_CFG_FILE | grep "server.${MYID}=" | wc -l`
           if [[ "$SERVER_FOUND" == "0" ]]; then
             echo "Server not found in ensemble. Exiting ..."
-            exit 0
+            exit 1
           fi
           SERVER=`cat $DYN_CFG_FILE | grep "server.${MYID}="`
-          if [[ $SERVER == *"participant"* ]]; then
+          if [[ ""$SERVER" == *"participant"* ]]; then
               ROLE=participant
-          else
+          elif [[ "$SERVER" == *"observer"* ]]; then
               ROLE=observer
           fi
       fi

--- a/docker/bin/zookeeperReady.sh
+++ b/docker/bin/zookeeperReady.sh
@@ -18,6 +18,7 @@ HOST=`hostname -s`
 DATA_DIR=/data
 MYID_FILE=$DATA_DIR/myid
 LOG4J_CONF=/conf/log4j-quiet.properties
+STATIC_CONFIG=/data/conf/zoo.cfg
 
 OK=$(echo ruok | nc 127.0.0.1 $CLIENT_PORT)
 
@@ -27,40 +28,57 @@ if [[ "$OK" == "imok" ]]; then
   set +e
   nslookup $DOMAIN
   if [[ $? -eq 1 ]]; then
-
     set -e
     echo "There is no active ensemble, skipping readiness probe..."
     exit 0
-
   else
     set -e
     # An ensemble exists, check to see if this node is already a member.
     # Check to see if zookeeper service for this node is a participant
     set +e
-    ZKURL=$(zkConnectionString)
-    set -e
-    MYID=`cat $MYID_FILE`
-    ROLE=`java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar get-role $ZKURL $MYID`
-
+    # Extract resource name and this members ordinal value from pod hostname
+    HOST=`hostname -s`
+    if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
+        NAME=${BASH_REMATCH[1]}
+        ORD=${BASH_REMATCH[2]}
+    else
+        echo Failed to parse name and ordinal of Pod
+        exit 1
+    fi
+    MYID=$((ORD+1))
+    ONDISK_CONFIG=false
+    if [ -f $MYID_FILE ]; then
+      EXISTING_ID="`cat $DATA_DIR/myid`"
+      if [[ "$EXISTING_ID" == "$MYID" && -f $STATIC_CONFIG ]]; then
+        # If Id is correct and configuration is present under `/data/conf`
+          ONDISK_CONFIG=true
+          DYN_CFG_FILE_LINE=`cat $STATIC_CONFIG|grep "dynamicConfigFile\="`
+          DYN_CFG_FILE=${DYN_CFG_FILE_LINE##dynamicConfigFile=}
+          SERVER_LINE=`cat $DYN_CFG_FILE | grep "server.${MYID}="`
+          if [[ $SERVER_LINE == *"participant"* ]]; then
+              ROLE=participant
+          else
+              ROLE=observer
+          fi
+      fi
+    fi
+    
     if [[ "$ROLE" == "participant" ]]; then
       echo "Zookeeper service is available and an active participant"
-      exit 0
-
+    exit 0
     elif [[ "$ROLE" == "observer" ]]; then
-
       echo "Zookeeper service is ready to be upgraded from observer to participant."
       ROLE=participant
+      ZKURL=$(zkConnectionString)
       ZKCONFIG=$(zkConfig)
       java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar remove $ZKURL $MYID
       sleep 1
       java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar add $ZKURL $MYID $ZKCONFIG
       exit 0
-
     else
       echo "Something has gone wrong. Unable to determine zookeeper role."
       exit 1
     fi
-
   fi
 
 else

--- a/docker/bin/zookeeperReady.sh
+++ b/docker/bin/zookeeperReady.sh
@@ -59,7 +59,7 @@ if [[ "$OK" == "imok" ]]; then
             exit 1
           fi
           SERVER=`cat $DYN_CFG_FILE | grep "server.${MYID}="`
-          if [[ ""$SERVER" == *"participant"* ]]; then
+          if [[ "$SERVER" == *"participant"* ]]; then
               ROLE=participant
           elif [[ "$SERVER" == *"observer"* ]]; then
               ROLE=observer
@@ -69,7 +69,7 @@ if [[ "$OK" == "imok" ]]; then
 
     if [[ "$ROLE" == "participant" ]]; then
       echo "Zookeeper service is available and an active participant"
-    exit 0
+      exit 0
     elif [[ "$ROLE" == "observer" ]]; then
       echo "Zookeeper service is ready to be upgraded from observer to participant."
       ROLE=participant

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -68,7 +68,6 @@ if [[ "$ACTIVE_ENSEMBLE" == false ]]; then
   # This is the first node being added to the cluster
   REGISTER_NODE=false
 else
-  # ACTIVE_ENSEMBLE == true
   # An ensemble exists, check to see if this node is already a member.
   if [[ "$ONDISK_CONFIG" == false ]]; then
     REGISTER_NODE=true

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -19,6 +19,7 @@ DATA_DIR=/data
 MYID_FILE=$DATA_DIR/myid
 LOG4J_CONF=/conf/log4j-quiet.properties
 DYNCONFIG=$DATA_DIR/zoo.cfg.dynamic
+STATIC_CONFIG=/data/conf/zoo.cfg
 
 # Extract resource name and this members ordinal value from pod hostname
 if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
@@ -31,100 +32,85 @@ fi
 
 MYID=$((ORD+1))
 
+# Values for first startup
 WRITE_CONFIGURATION=true
 REGISTER_NODE=true
+ONDISK_CONFIG=false
 
 # Check validity of on-disk configuration
 if [ -f $MYID_FILE ]; then
   EXISTING_ID="`cat $DATA_DIR/myid`"
-  if [[ "$EXISTING_ID" == "$MYID" || -f $DYNCONFIG ]]; then
-      WRITE_CONFIGURATION=false
+  if [[ "$EXISTING_ID" == "$MYID" && -f $STATIC_CONFIG ]]; then
+    # If Id is correct and configuration is present under `/data/conf`
+      ONDISK_CONFIG=true
   fi
-
 fi
 
 # Determine if there is a ensemble available to join by checking the service domain
-
 set +e
 nslookup $DOMAIN
 if [[ $? -eq 1 ]]; then
-  set -e
   # If an nslookup of the headless service domain fails, then there is no
   # active ensemble
-  WRITE_CONFIGURATION=true
-  REGISTER_NODE=false
-
+  ACTIVE_ENSEMBLE=false
 else
-  set -e
-  # An ensemble exists, check to see if this node is already a member.
-  set +e
-  ZKURL=$(zkConnectionString)
-  set -e
-  CONFIG=`java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar get-all $ZKURL`
-  REGISTERED=`echo "$CONFIG" | grep "server.${MYID}=" | wc -l`
+  ACTIVE_ENSEMBLE=true
+fi
 
-  if [[ $REGISTERED -eq 1 ]]; then
-    REGISTER_NODE=false
-
-  else
-    # When registering the node to the ensemble, always [re]write the config
-    REGISTER_NODE=true
+if [[ "$ONDISK_CONFIG" == true ]]; then
+  # If Configuration is present, we assume, there is no need to write configuration.
+    WRITE_CONFIGURATION=false
+else
     WRITE_CONFIGURATION=true
+fi
 
+if [[ "$ACTIVE_ENSEMBLE" == false ]]; then
+  # This is the first node being added to the cluster
+  REGISTER_NODE=false
+else
+  # ACTIVE_ENSEMBLE == true
+  # An ensemble exists, check to see if this node is already a member.
+  if [[ "$ONDISK_CONFIG" == false ]]; then
+    REGISTER_NODE=true
+  else
+    REGISTER_NODE=false
   fi
 fi
 
 if [[ "$WRITE_CONFIGURATION" == true ]]; then
   echo "Writing myid: $MYID to: $MYID_FILE."
   echo $MYID > $MYID_FILE
-
-  if [[ $MYID -eq 1 && "$REGISTER_NODE" == false ]]; then
+  if [[ $MYID -eq 1 ]]; then
     ROLE=participant
     echo Initial initialization of ordinal 0 pod, creating new config.
     ZKCONFIG=$(zkConfig)
-
     echo Writing bootstrap configuration with the following config:
     echo $ZKCONFIG
     echo $MYID > $MYID_FILE
     echo "server.${MYID}=${ZKCONFIG}" > $DYNCONFIG
-
-  elif [[ $MYID -ne 1 && "$REGISTER_NODE" == false ]]; then
+  else
     echo Writing configuration gleaned from zookeeper ensemble
     echo "$CONFIG" | grep -v "^version="> $DYNCONFIG
+  fi
+fi
 
-  elif [[ "$REGISTER_NODE" == true ]]; then
+if [[ "$REGISTER_NODE" == true ]]; then
     ROLE=observer
+    ZKURL=$(zkConnectionString)
     ZKCONFIG=$(zkConfig)
-
     echo Registering node and writing local configuration to disk.
     java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar add $ZKURL $MYID  $ZKCONFIG $DYNCONFIG
-  fi
 fi
 
 ZOOCFGDIR=/data/conf
 export ZOOCFGDIR
-
 if [[ ! -d "$ZOOCFGDIR" ]]; then
-  echo Copying /conf contents to writable directory, to support Zookeeper dynamic reconfiguraiton
+  echo Copying /conf contents to writable directory, to support Zookeeper dynamic reconfiguration
   mkdir $ZOOCFGDIR
   cp -f /conf/zoo.cfg $ZOOCFGDIR
   cp -f /conf/log4j.properties $ZOOCFGDIR
   cp -f /conf/log4j-quiet.properties $ZOOCFGDIR
   cp -f /conf/env.sh $ZOOCFGDIR
-fi
-
-if [[ "$WRITE_CONFIGURATION" == false && "$REGISTER_NODE" == false ]]; then
-  # We get here only on server restart...
-  echo Bootstrap dynamic config file
-  cat $DYNCONFIG
-  echo Static Config file
-  STATIC_CONFIG=`cat $ZOOCFGDIR/zoo.cfg`
-  echo Setting dynamic configuration to cluster configuration fetched from zk-service
-  echo "$CONFIG" | grep -v "^version="> $DYNCONFIG
-  cat $DYNCONFIG
-  #Setting dynamicConfigFile=/data/zoo.cfg.dynamic in zoo.cfg
-  sed -i 's/dynamicConfigFile=.*/dynamicConfigFile=\/data\/zoo\.cfg\.dynamic/g' $ZOOCFGDIR/zoo.cfg
-  cat $ZOOCFGDIR/zoo.cfg
 fi
 
 echo Starting zookeeper service

--- a/docker/bin/zookeeperTeardown.sh
+++ b/docker/bin/zookeeperTeardown.sh
@@ -24,9 +24,6 @@ ZKURL=$(zkConnectionString)
 set -e
 MYID=`cat $MYID_FILE`
 
-# Remove server from zk configuration
-java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar remove $ZKURL $MYID
-
 # Wait for client connections to drain. Kubernetes will wait until the confiugred
 # "terminationGracePeriodSeconds" before focibly killing the container
 CONN_COUNT=`echo cons | nc localhost 2181 | grep -v "^$" |grep -v "/127.0.0.1:" | wc -l`

--- a/docker/bin/zookeeperTeardown.sh
+++ b/docker/bin/zookeeperTeardown.sh
@@ -24,6 +24,12 @@ ZKURL=$(zkConnectionString)
 set -e
 MYID=`cat $MYID_FILE`
 
+echo "Cluster size=$CLUSTER_SIZE, MyId=$MYID"
+if [[ "$CLUSTER_SIZE" -lt "$MYID" ]]; then
+  # If ClusterSize < MyId, this server is being permanantly removed.
+  java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar remove $ZKURL $MYID
+  echo $?
+fi
 # Wait for client connections to drain. Kubernetes will wait until the confiugred
 # "terminationGracePeriodSeconds" before focibly killing the container
 CONN_COUNT=`echo cons | nc localhost 2181 | grep -v "^$" |grep -v "/127.0.0.1:" | wc -l`

--- a/docker/zu/src/main/java/io/pravega/zookeeper/Zookeeper.kt
+++ b/docker/zu/src/main/java/io/pravega/zookeeper/Zookeeper.kt
@@ -17,21 +17,7 @@ import org.apache.zookeeper.admin.ZooKeeperAdmin
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
-const val ZK_CONNECTION_TIMEOUT_MINS: Long  = 10
-
-/**
- * Creates a new Zookeeper client and waits until it's in a connected state
-
-fun newZookeeperClient(zkUrl: String) : ZooKeeper {
-    System.err.println("Connecting to Zookeeper $zkUrl")
-    val connectionWatcher = ConnectionWatcher()
-    val zk = ZooKeeper(zkUrl, 3000, connectionWatcher)
-
-    connectionWatcher.waitUntilConnected()
-
-    return zk
-}
- */
+const val ZK_CONNECTION_TIMEOUT_MINS: Long  = 3
 
 /**
  * Creates a new Zookeeper Admin client and waits until it's in a connected state
@@ -62,4 +48,3 @@ class ConnectionWatcher : Watcher {
         connected.get(ZK_CONNECTION_TIMEOUT_MINS, TimeUnit.MINUTES)
     }
 }
-

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -219,7 +219,8 @@ func makeZkEnvConfigString(z *v1beta1.ZookeeperCluster) string {
 		"QUORUM_PORT=" + strconv.Itoa(int(ports.Quorum)) + "\n" +
 		"LEADER_PORT=" + strconv.Itoa(int(ports.Leader)) + "\n" +
 		"CLIENT_HOST=" + z.GetClientServiceName() + "\n" +
-		"CLIENT_PORT=" + strconv.Itoa(int(ports.Client)) + "\n"
+		"CLIENT_PORT=" + strconv.Itoa(int(ports.Client)) + "\n" +
+		"CLUSTER_SIZE=" + fmt.Sprint(z.Spec.Replicas) + "\n"
 }
 
 func makeService(name string, ports []v1.ServicePort, clusterIP bool, z *v1beta1.ZookeeperCluster) *v1.Service {


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

Change log description
Changed zookeeper startup, shutdown and readiness scripts to deal with server restarts without invoking "reconfig".

Purpose of the change
Fixes #92

What the code does
Changes the way we handle zookeeper server restarts
TDB: Changes to Zookeeper-operator for handling permanent deletion of servers from zookeeper ensemble when we choose to scale down the zk cluster. For addition of new clusters to the ensemble (on scale up), that is already covered by the existing zookeeperStart.sh script.

How to verify it
All tests should pass.
Manually tested this on a 3 node zookeeper cluster.
Tried deleting all 3 nodes, one at a time and they came back up successfully.
Tried deleting 2 nodes at a time and they came back up successfully.
Tried deleting all 3 nodes in the cluster and the cluster was restored back in <5 mins.