### PR TITLE
Make zk listen to `0.0.0.0` for ports `2888`/`3888`

### DIFF
--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -191,6 +191,7 @@ func makeZkConfigString(s v1beta1.ZookeeperClusterSpec) string {
 		"initLimit=" + strconv.Itoa(s.Conf.InitLimit) + "\n" +
 		"syncLimit=" + strconv.Itoa(s.Conf.SyncLimit) + "\n" +
 		"tickTime=" + strconv.Itoa(s.Conf.TickTime) + "\n" +
+	        "quorumListenOnAllIPs=true\n" +
 		"dynamicConfigFile=/data/zoo.cfg.dynamic\n"
 }
 


### PR DESCRIPTION
as said here (https://github.com/istio/istio/issues/19280#issuecomment-560542530), zookeeper doesn't listen on `0.0.0.0` per default for leader election and follower ports and then is not "service mesh friendly".
Adding this option makes it listen to `0.0.0.0` for port `2888`/`3888` and not one IP address.

closes #102 