### PR TITLE
Issue 102: Make zookeeper istio friendly

### DIFF
--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -191,6 +191,7 @@ func makeZkConfigString(s v1beta1.ZookeeperClusterSpec) string {
 		"initLimit=" + strconv.Itoa(s.Conf.InitLimit) + "\n" +
 		"syncLimit=" + strconv.Itoa(s.Conf.SyncLimit) + "\n" +
 		"tickTime=" + strconv.Itoa(s.Conf.TickTime) + "\n" +
+		"quorumListenOnAllIPs=true\n" +
 		"dynamicConfigFile=/data/zoo.cfg.dynamic\n"
 }
 


### PR DESCRIPTION
as said in https://github.com/istio/istio/issues/19280#issuecomment-560542530, zookeeper doesn't listen on 0.0.0.0 per default and then is not "service mesh friendly".

Adding `quorumListenOnAllIPs` to `true` makes it listen to all ports and not one IP address.

Signed-off-by: Sylvain Desbureaux <sylvain.desbureaux@orange.com>