### PR TITLE
Changes for zk operator to be stateless

### DIFF
--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -88,8 +88,12 @@ if [[ "$WRITE_CONFIGURATION" == true ]]; then
     echo $MYID > $MYID_FILE
     echo "server.${MYID}=${ZKCONFIG}" > $DYNCONFIG
   else
+    set -e
+    ZKURL=$(zkConnectionString)
+    CONFIG=`java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar get-all $ZKURL`
     echo Writing configuration gleaned from zookeeper ensemble
     echo "$CONFIG" | grep -v "^version="> $DYNCONFIG
+    set +e
   fi
 fi
 
@@ -97,8 +101,10 @@ if [[ "$REGISTER_NODE" == true ]]; then
     ROLE=observer
     ZKURL=$(zkConnectionString)
     ZKCONFIG=$(zkConfig)
+    set -e
     echo Registering node and writing local configuration to disk.
     java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar add $ZKURL $MYID  $ZKCONFIG $DYNCONFIG
+    set +e
 fi
 
 ZOOCFGDIR=/data/conf


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

## Change log description
Removed `skipSTSReconcile` since it was a global variable that broke the stateless nature of zookeeper operator. Added a sleep of 2 minutes to fix the config map sync problem.
Considered/tried multiple alternatives like 
1. Update an annotation on the STS after configmap is updated so it triggers the volume sync: The problem with this approach is that when K8s restarts pods for the annotation update to take effect, the server when going down (_in teardown.sh_) is removed from ensemble and hence when it comes back up is not able to join the ensemble again.
2. Remove scaled down servers in readiness/liveness probe of existing servers: Update cluster_size in ZK config-map. Do not remove the scaled down servers in the tear-down script but remove them in a readiness probe of some existing zk server. This approach works fine during a scale down, but during a "scale-up", if a new server comes up and is added to ensemble config, but config-map is not updated yet with the new cluster size, then the readiness probe for an existing server deletes this new server assuming it was left over from last scale down.
3. Use a variable to skip certain number of reconcile attempts after configmap is updated with scaled down replica count: Adding skipSTSReconcile variable to ZookeeperClusterStatus and counting on a certain number of skipped reconciles before updating the STS with the new replica count does not guarantee that we will wait for 2 minutes before updating the STS, since reconcile can get invoked for reasons other than the reconcile time expiring. 

Hence finally choose this simple approach.

## Purpose of the change
Fixes #103 #104 

## How to verify it
Verified by scaling the cluster up and down multiple times and there were no issues with cluster scale and pod restarts. 
