### PR TITLE
Issue 102: Add support for ZK to be able to run on Istio enabled cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ metadata:
   name: zk-with-istio
 spec:
   replicas: 3
-  isIstioEnabled: true
   config:
     initLimit: 10
     tickTime: 2000

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The project is currently alpha. While no breaking API changes are currently plan
  * [Usage](#usage)    
     * [Installation of the Operator](#install-the-operator)
     * [Deploy a sample Zookeeper Cluster](#deploy-a-sample-zookeeper-cluster)
+    * [Deploy a sample Zookeeper Cluster to a cluster using Istio](#deploy-a-sample-zookeeper-cluster-with-istio)
     * [Upgrade a Zookeeper Cluster](#upgrade-a-zookeeper-cluster)
     * [Uninstall the Zookeeper Cluster](#uninstall-the-zookeeper-cluster)
     * [Uninstall the Operator](#uninstall-the-operator)
@@ -128,6 +129,28 @@ po/example-2   1/1       Running   0          1m
 NAME                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
 svc/example-client     ClusterIP   10.31.243.173   <none>        2181/TCP            2m
 svc/example-headless   ClusterIP   None            <none>        2888/TCP,3888/TCP   2m
+```
+
+### Deploy a sample Zookeeper cluster with Istio
+Create a Yaml file called `zk-with-istio.yaml` with the following content to install a 3-node Zookeeper cluster.
+
+```yaml
+apiVersion: zookeeper.pravega.io/v1beta1
+kind: ZookeeperCluster
+metadata:
+  name: zk-with-istio
+spec:
+  replicas: 3
+  isIstioEnabled: true
+  config:
+    initLimit: 10
+    tickTime: 2000
+    syncLimit: 5
+    quorumListenOnAllIPs: true
+```
+
+```
+$ kubectl create -f zk-with-istio.yaml
 ```
 
 ### Upgrade a Zookeeper cluster

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,10 +14,8 @@ COPY zu /zu
 WORKDIR /zu
 RUN ./gradlew assemble
 
-FROM zookeeper:3.5.5
+FROM zookeeper:3.5.4-beta
 COPY bin /usr/local/bin
+RUN apk add curl
 RUN chmod +x /usr/local/bin/*
 COPY --from=0 /zu/build/libs/zu.jar /root/
-
-RUN apt-get -q update && \
-    apt-get install -y dnsutils

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,8 @@ RUN ./gradlew assemble
 
 FROM zookeeper:3.5.5
 COPY bin /usr/local/bin
-RUN apt update && apt install curl -y
 RUN chmod +x /usr/local/bin/*
 COPY --from=0 /zu/build/libs/zu.jar /root/
+
+RUN apt-get -q update && \
+    apt-get install -y dnsutils curl

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,8 @@ COPY zu /zu
 WORKDIR /zu
 RUN ./gradlew assemble
 
-FROM zookeeper:3.5.4-beta
+FROM zookeeper:3.5.5
 COPY bin /usr/local/bin
-RUN apk add curl
+RUN apt update && apt install curl -y
 RUN chmod +x /usr/local/bin/*
 COPY --from=0 /zu/build/libs/zu.jar /root/

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -51,6 +51,22 @@ if [ -f $DYNCONFIG ]; then
   ONDISK_DYN_CONFIG=true
 fi
 
+# Check if envoy is up and running
+if [[ "$IS_ISTIO_ENABLED" == true ]]; then
+  COUNT=0
+  MAXCOUNT=${1:-30}
+  HEALTHYSTATUSCODE="200"
+  while true; do
+    COUNT=`expr $COUNT + 1`
+    SC=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:15000/ready)
+    echo "waiting for envoy proxy to come up";
+    sleep 1;
+    if (( "$SC" == "$HEALTHYSTATUSCODE" || "$MAXCOUNT" == "$COUNT" )); then
+      break
+    fi
+  done
+fi
+
 # Determine if there is a ensemble available to join by checking the service domain
 set +e
 nslookup $DOMAIN

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -52,12 +52,12 @@ if [ -f $DYNCONFIG ]; then
 fi
 
 # Check if envoy is up and running
-if [[ "$IS_ISTIO_ENABLED" == true ]]; then
+if [[ -n "$ENVOY_SIDECAR_STATUS" ]]; then
   COUNT=0
   MAXCOUNT=${1:-30}
   HEALTHYSTATUSCODE="200"
   while true; do
-    COUNT=`expr $COUNT + 1`
+    COUNT=$(expr $COUNT + 1)
     SC=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:15000/ready)
     echo "waiting for envoy proxy to come up";
     sleep 1;

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -314,6 +314,14 @@ type ZookeeperConfig struct {
 	//
 	// The default value is 2.
 	SyncLimit int `json:"syncLimit"`
+
+	// QuorumListenOnAllIPs when set to true the ZooKeeper server will listen for
+	// connections from its peers on all available IP addresses, and not only the
+	// address configured in the server list of the configuration file. It affects
+	// the connections handling the ZAB protocol and the Fast Leader Election protocol.
+	//
+	// The default value is false.
+	QuorumListenOnAllIPs bool `json:"quorumListenOnAllIPs"`
 }
 
 func (c *ZookeeperConfig) withDefaults() (changed bool) {

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -198,6 +198,7 @@ func makeZkConfigString(s v1beta1.ZookeeperClusterSpec) string {
 		"initLimit=" + strconv.Itoa(s.Conf.InitLimit) + "\n" +
 		"syncLimit=" + strconv.Itoa(s.Conf.SyncLimit) + "\n" +
 		"tickTime=" + strconv.Itoa(s.Conf.TickTime) + "\n" +
+		"quorumListenOnAllIPs=" + strconv.FormatBool(s.Conf.QuorumListenOnAllIPs) + "\n" +
 		"dynamicConfigFile=/data/zoo.cfg.dynamic\n"
 }
 

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -88,9 +88,19 @@ func MakeStatefulSet(z *v1beta1.ZookeeperCluster) *appsv1.StatefulSet {
 
 func makeZkPodSpec(z *v1beta1.ZookeeperCluster) v1.PodSpec {
 	zkContainer := v1.Container{
-		Name:            "zookeeper",
-		Image:           z.Spec.Image.ToString(),
-		Ports:           z.Spec.Ports,
+		Name:  "zookeeper",
+		Image: z.Spec.Image.ToString(),
+		Ports: z.Spec.Ports,
+		Env: []v1.EnvVar{
+			{
+				Name: "ENVOY_SIDECAR_STATUS",
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						FieldPath: `metadata.annotations['sidecar.istio.io/status']`,
+					},
+				},
+			},
+		},
 		ImagePullPolicy: z.Spec.Image.PullPolicy,
 		ReadinessProbe: &v1.Probe{
 			InitialDelaySeconds: 10,
@@ -122,7 +132,7 @@ func makeZkPodSpec(z *v1beta1.ZookeeperCluster) v1.PodSpec {
 	if z.Spec.Pod.Resources.Limits != nil || z.Spec.Pod.Resources.Requests != nil {
 		zkContainer.Resources = z.Spec.Pod.Resources
 	}
-	zkContainer.Env = z.Spec.Pod.Env
+	zkContainer.Env = append(zkContainer.Env, z.Spec.Pod.Env...)
 	podSpec := v1.PodSpec{
 		Containers: []v1.Container{zkContainer},
 		Affinity:   z.Spec.Pod.Affinity,


### PR DESCRIPTION
This PR adds support to enable `quorumListenOnAllIPs`. This config is required for Zookeeper to be able to run on an Istio based environment.
Some modification must be done in the zookeeperStartup script as well, since it uses `nslookup` to determine if the ZkServer is part of an ensemble or not. In case of Istio all the communication goes through the sidecar container which might not ready when the nslookup command issued. So we might need to wait a while to the sidecar to become ready. This script can be removed when Kubernetes 1.17 is more commonly used.

I also modified the Zookeeper docker container slightly, to add `curl`. Also I could not make the official 3.5.5 image work, I am guessing something wrong there, since it also does not work in a non Istio environment.
Fixes: #102 
