### PR TITLE
Issue 107: Allowing DNS annotations to be added to zookeeper headless service

### DIFF
--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -67,6 +67,9 @@ type ZookeeperClusterSpec struct {
 	// static zookeeper configuration. If no configuration is provided required
 	// default values will be provided, and optional values will be excluded.
 	Conf ZookeeperConfig `json:"config,omitempty"`
+
+	// Domain Name to be used for DNS
+	DomainName string `json:"domainName,omitempty"`
 }
 
 func (s *ZookeeperClusterSpec) withDefaults(z *ZookeeperCluster) (changed bool) {

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -231,8 +231,10 @@ func makeZkEnvConfigString(z *v1beta1.ZookeeperCluster) string {
 
 func makeService(name string, ports []v1.ServicePort, clusterIP bool, z *v1beta1.ZookeeperCluster) *v1.Service {
 	var dnsName string
+	var dnsEnabled bool
 	var annotationMap map[string]string
 	if clusterIP && z.Spec.DomainName != "" {
+		dnsEnabled = true
 		domainName := strings.TrimSpace(z.Spec.DomainName)
 		if strings.HasSuffix(domainName, dot) {
 			dnsName = name + dot + domainName
@@ -241,6 +243,7 @@ func makeService(name string, ports []v1.ServicePort, clusterIP bool, z *v1beta1
 		}
 		annotationMap = map[string]string{externalDNSAnnotationKey: dnsName}
 	} else {
+		dnsEnabled = false
 		annotationMap = map[string]string{}
 	}
 	service := v1.Service{
@@ -266,7 +269,7 @@ func makeService(name string, ports []v1.ServicePort, clusterIP bool, z *v1beta1
 			Selector: map[string]string{"app": z.GetName()},
 		},
 	}
-	if clusterIP == false {
+	if dnsEnabled || clusterIP == false {
 		service.Spec.ClusterIP = v1.ClusterIPNone
 	}
 	return &service

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -231,10 +231,8 @@ func makeZkEnvConfigString(z *v1beta1.ZookeeperCluster) string {
 
 func makeService(name string, ports []v1.ServicePort, clusterIP bool, z *v1beta1.ZookeeperCluster) *v1.Service {
 	var dnsName string
-	var dnsEnabled bool
 	var annotationMap map[string]string
-	if clusterIP && z.Spec.DomainName != "" {
-		dnsEnabled = true
+	if !clusterIP && z.Spec.DomainName != "" {
 		domainName := strings.TrimSpace(z.Spec.DomainName)
 		if strings.HasSuffix(domainName, dot) {
 			dnsName = name + dot + domainName
@@ -243,7 +241,6 @@ func makeService(name string, ports []v1.ServicePort, clusterIP bool, z *v1beta1
 		}
 		annotationMap = map[string]string{externalDNSAnnotationKey: dnsName}
 	} else {
-		dnsEnabled = false
 		annotationMap = map[string]string{}
 	}
 	service := v1.Service{
@@ -269,7 +266,7 @@ func makeService(name string, ports []v1.ServicePort, clusterIP bool, z *v1beta1
 			Selector: map[string]string{"app": z.GetName()},
 		},
 	}
-	if dnsEnabled || clusterIP == false {
+	if !clusterIP {
 		service.Spec.ClusterIP = v1.ClusterIPNone
 	}
 	return &service

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/pravega/zookeeper-operator/pkg/apis/zookeeper/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,6 +23,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	externalDNSAnnotationKey = "external-dns.alpha.kubernetes.io/hostname"
+	dot                      = "."
 )
 
 func headlessDomain(z *v1beta1.ZookeeperCluster) string {
@@ -224,6 +230,19 @@ func makeZkEnvConfigString(z *v1beta1.ZookeeperCluster) string {
 }
 
 func makeService(name string, ports []v1.ServicePort, clusterIP bool, z *v1beta1.ZookeeperCluster) *v1.Service {
+	var dnsName string
+	var annotationMap map[string]string
+	if clusterIP && z.Spec.DomainName != "" {
+		domainName := strings.TrimSpace(z.Spec.DomainName)
+		if strings.HasSuffix(domainName, dot) {
+			dnsName = name + dot + domainName
+		} else {
+			dnsName = name + dot + domainName + dot
+		}
+		annotationMap = map[string]string{externalDNSAnnotationKey: dnsName}
+	} else {
+		annotationMap = map[string]string{}
+	}
 	service := v1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
@@ -239,7 +258,8 @@ func makeService(name string, ports []v1.ServicePort, clusterIP bool, z *v1beta1
 					Kind:    "ZookeeperCluster",
 				}),
 			},
-			Labels: map[string]string{"app": z.GetName()},
+			Labels:      map[string]string{"app": z.GetName()},
+			Annotations: annotationMap,
 		},
 		Spec: v1.ServiceSpec{
 			Ports:    ports,

--- a/pkg/zk/generators_test.go
+++ b/pkg/zk/generators_test.go
@@ -151,10 +151,9 @@ var _ = Describe("Generators Spec", func() {
 			Ω(s.Spec.Selector["app"]).To(Equal("example"))
 		})
 
-		It("should set the dns annotation", func() {
-			Expect(s.GetAnnotations()).To(HaveKeyWithValue(
-				"external-dns.alpha.kubernetes.io/hostname",
-				"example-client.zk.com."))
+		It("should not set the dns annotation", func() {
+			mapLength := len(s.GetAnnotations())
+			Ω(mapLength).To(Equal(0))
 		})
 	})
 
@@ -197,9 +196,10 @@ var _ = Describe("Generators Spec", func() {
 			Ω(s.Spec.Selector["app"]).To(Equal("example"))
 		})
 
-		It("should not set any annotations", func() {
-			mapLength := len(s.GetAnnotations())
-			Ω(mapLength).To(Equal(0))
+		It("should set the dns annotation", func() {
+			Expect(s.GetAnnotations()).To(HaveKeyWithValue(
+				"external-dns.alpha.kubernetes.io/hostname",
+				"example-headless.zk.com."))
 		})
 	})
 })

--- a/pkg/zk/generators_test.go
+++ b/pkg/zk/generators_test.go
@@ -120,12 +120,17 @@ var _ = Describe("Generators Spec", func() {
 
 	Context("#MakeClientService", func() {
 		var s *v1.Service
+		var domainName string
 
 		BeforeEach(func() {
+			domainName = "zk.com."
 			z := &v1beta1.ZookeeperCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "example",
 					Namespace: "default",
+				},
+				Spec: v1beta1.ZookeeperClusterSpec{
+					DomainName: domainName,
 				},
 			}
 			z.WithDefaults()
@@ -145,16 +150,27 @@ var _ = Describe("Generators Spec", func() {
 		It("should have a the client svc name", func() {
 			Ω(s.Spec.Selector["app"]).To(Equal("example"))
 		})
+
+		It("should set the dns annotation", func() {
+			Expect(s.GetAnnotations()).To(HaveKeyWithValue(
+				"external-dns.alpha.kubernetes.io/hostname",
+				"example-client.zk.com."))
+		})
 	})
 
 	Context("#MakeHeadlessService", func() {
 		var s *v1.Service
+		var domainName string
 
 		BeforeEach(func() {
+			domainName = "zk.com."
 			z := &v1beta1.ZookeeperCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "example",
 					Namespace: "default",
+				},
+				Spec: v1beta1.ZookeeperClusterSpec{
+					DomainName: domainName,
 				},
 			}
 			z.WithDefaults()
@@ -179,6 +195,11 @@ var _ = Describe("Generators Spec", func() {
 
 		It("should have a the client svc name", func() {
 			Ω(s.Spec.Selector["app"]).To(Equal("example"))
+		})
+
+		It("should not set any annotations", func() {
+			mapLength := len(s.GetAnnotations())
+			Ω(mapLength).To(Equal(0))
 		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Added dns annotation to zookeeper headless service that can be used to assign a dns name to the service.

### Purpose of the change
Fixes #107 

### What the code does
Added `domainName` to the Zookeeper Cluster Spec, that can be set via manifest.
`FQDN for zookeeper headless service = serviceName.domainName.` ( ends with a . )

Added an annotation `external-dns.alpha.kubernetes.io/hostname` to the zookeeper headless service.
If domain name is not set in the manifest, this annotation is also not set.

### How to verify it
1. In Zookeeper spec, set `domainName=example.com.`
2. **kubectl describe svc zookeeper-headless** should show :
 ```Annotations: external-dns.alpha.kubernetes.io/hostname: zookeeper-headless.example.com.```