### PR TITLE
Customised docker file for docker swarm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,17 +54,21 @@ build-zk-image:
 	docker build --build-arg VERSION=$(VERSION) --build-arg GIT_SHA=$(GIT_SHA) -t $(APP_REPO):$(VERSION) ./docker
 	docker tag $(APP_REPO):$(VERSION) $(APP_REPO):latest
 
+build-zk-image-swarm:
+	docker build --build-arg VERSION=$(VERSION)-swarm --build-arg GIT_SHA=$(GIT_SHA) -f ./docker/Dockerfile-swarm  -t $(APP_REPO):$(VERSION)-swarm  ./docker
+        
 test:
 	go test $$(go list ./... | grep -v /vendor/) -race -coverprofile=coverage.txt -covermode=atomic
 
 login:
 	@docker login -u "$(DOCKER_USER)" -p "$(DOCKER_PASS)"
 
-push: build-image build-zk-image login
+push: build-image build-zk-image  build-zk-image-swarm login
 	docker push $(REPO):$(VERSION)
 	docker push $(REPO):latest
 	docker push $(APP_REPO):$(VERSION)
 	docker push $(APP_REPO):latest
+	docker push $(APP_REPO):$(VERSION)-swarm         
 	docker tag $(REPO):$(VERSION) $(ALTREPO):$(VERSION)
 	docker tag $(REPO):$(VERSION) $(ALTREPO):latest
 	docker tag $(APP_REPO):$(VERSION) $(APP_ALTREPO):$(VERSION)

--- a/docker/Dockerfile-swarm
+++ b/docker/Dockerfile-swarm
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+
+FROM zookeeper:3.5.6
+COPY zoo.cfg.swarm /conf/zoo.cfg

--- a/docker/Dockerfile-swarm
+++ b/docker/Dockerfile-swarm
@@ -8,5 +8,5 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 
-FROM zookeeper:3.5.6
+FROM zookeeper:3.5.5
 COPY zoo.cfg.swarm /conf/zoo.cfg

--- a/docker/zoo.cfg.swarm
+++ b/docker/zoo.cfg.swarm
@@ -1,0 +1,12 @@
+dataDir=/data
+dataLogDir=/datalog
+tickTime=2000
+initLimit=5
+syncLimit=2
+autopurge.snapRetainCount=3
+autopurge.purgeInterval=0
+maxClientCnxns=60
+standaloneEnabled=true
+admin.enableServer=true
+server.1=localhost:2888:3888;2181
+4lw.commands.whitelist=cons, envi, conf, crst, srvr, stat, mntr, ruok


### PR DESCRIPTION
Created docker file to whitelist the `ruok` command. `netstat` got removed from `zookeeper:3.5.5` onwards.  Customised docker file will be used for docker swarm tests.

Fixes #122 
Signed-off-by: anisha.kj <anisha.kj@emc.com>