### PR TITLE
Issue 124: The additionalPrinterColumn of the Zookeeper Cluster "replicas" prints incorrect value

### DIFF
--- a/charts/zookeeper-operator/Chart.yaml
+++ b/charts/zookeeper-operator/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper-operator
-version: 0.2.5
-appVersion: 0.2.5
+version: latest
+appVersion: latest
 description: zookeeper operator Helm chart for Kubernetes
 keywords:
 - zookeeper

--- a/charts/zookeeper-operator/Chart.yaml
+++ b/charts/zookeeper-operator/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper-operator
-version: 0.2.2
-appVersion: 0.2.2
+version: 0.2.5
+appVersion: 0.2.5
 description: zookeeper operator Helm chart for Kubernetes
 keywords:
 - zookeeper

--- a/charts/zookeeper-operator/templates/crd.yaml
+++ b/charts/zookeeper-operator/templates/crd.yaml
@@ -13,6 +13,22 @@ spec:
     shortNames:
     - zk
   additionalPrinterColumns:
+  - name: Replicas
+    type: integer
+    description: The number of ZooKeeper servers in the ensemble
+    JSONPath: .spec.replicas
+  - name: Ready Replicas
+    type: integer
+    description: The number of ZooKeeper servers in the ensemble that are in a Ready state
+    JSONPath: .status.readyReplicas
+  - name: Internal Endpoint
+    type: string
+    description: Client endpoint internal to cluster network
+    JSONPath: .status.internalClientEndpoint
+  - name: External Endpoint
+    type: string
+    description: Client endpoint external to cluster network via LoadBalancer
+    JSONPath: .status.externalClientEndpoint
   - name: Age
     type: date
     JSONPath: .metadata.creationTimestamp

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: pravega/zookeeper-operator
-  tag: 0.2.2
+  tag: latest
   pullPolicy: IfNotPresent
 
 ## Install RBAC roles and bindings

--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
-version: 0.2.2
-appVersion: 0.2.2
+version: 0.2.5
+appVersion: 0.2.5
 description: zookeeper Helm chart for Kubernetes
 keywords:
 - zookeeper

--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
-version: 0.2.5
-appVersion: 0.2.5
+version: latest
+appVersion: latest
 description: zookeeper Helm chart for Kubernetes
 keywords:
 - zookeeper

--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -4,3 +4,6 @@ metadata:
   name: {{ template "zookeeper.fullname" . }}
 spec:
   replicas: 3
+  image:
+    repository: {{ with .Values.image }}{{ .repository }}{{ end }}
+    tag: {{ with .Values.image }}{{ .tag }}{{ end }}

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -1,4 +1,4 @@
 image:
   repository: pravega/zookeeper
-  tag: 0.2.2
+  tag: latest
   pullPolicy: IfNotPresent

--- a/deploy/crds/zookeeper_v1beta1_zookeepercluster_crd.yaml
+++ b/deploy/crds/zookeeper_v1beta1_zookeepercluster_crd.yaml
@@ -15,7 +15,7 @@ spec:
   - name: Replicas
     type: integer
     description: The number of ZooKeeper servers in the ensemble
-    JSONPath: .status.replicas
+    JSONPath: .spec.replicas
   - name: Ready Replicas
     type: integer
     description: The number of ZooKeeper servers in the ensemble that are in a Ready state


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
The additional printer column `Replicas` which is part of the Zookeeper Cluster CRD prints the value in `.Status.Replicas` field of the Zookeeper Cluster object which is incorrect. This value should be picked from the object Spec and not its Status.

### Purpose of the change
Fixes #124 

### How to verify it
Deployed the Zookeeper Cluster both using charts and manually and confirmed that value printed by the replicas field on doing `kubectl get zk` now prints the correct value.