### PR TITLE
Sync helm chart RBAC with generated files

### DIFF
--- a/charts/zookeeper-operator/templates/clusterrole.yaml
+++ b/charts/zookeeper-operator/templates/clusterrole.yaml
@@ -13,15 +13,28 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
   verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
   - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
   verbs:
-  - '*'
+  - "*"
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - "*"
 {{- end }}


### PR DESCRIPTION
Helm ClusterRole rules were out of date with the files generated in `deploy`.
