### PR TITLE
Observers fail to register when zk ensemble service domain is not yet available

### DIFF
--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -125,13 +125,6 @@ if [[ "$WRITE_CONFIGURATION" == true ]]; then
     echo $ZKCONFIG
     echo $MYID > $MYID_FILE
     echo "server.${MYID}=${ZKCONFIG}" > $DYNCONFIG
-  else
-    set -e
-    ZKURL=$(zkConnectionString)
-    CONFIG=`java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar get-all $ZKURL`
-    echo Writing configuration gleaned from zookeeper ensemble
-    echo "$CONFIG" | grep -v "^version="> $DYNCONFIG
-    set +e
   fi
 fi
 


### PR DESCRIPTION
### Change log description

When ensemble DOMAIN is not yet available (happens in k8s when svc domain dns resolve is slow to resolve), observer peers (id>=2) fail to register and enter a crash loop.
Previously the DYNCONFIG was populated with peer nodes but `REGISTER_NODE` is false (domain not yet available) hence the `zu add` never called. Subsequently when peer is restarted the registration is never called

### Purpose of the change
 Fixes  #315

### What the code does

DYNCONFIG is not updated, if ensemble is not available for pods starting from ID 2  

### How to verify it
Verified that second zookeeper pod is starting successfully.