### PR TITLE
Issue 139: Zookeeper operator is not updating cluster status correctly

### DIFF
--- a/pkg/utils/zookeeper_util.go
+++ b/pkg/utils/zookeeper_util.go
@@ -25,7 +25,7 @@ const (
 
 func GetZkServiceUri(zoo *v1beta1.ZookeeperCluster) (zkUri string) {
 	zkClientPort, _ := ContainerPortByName(zoo.Spec.Ports, "client")
-	zkUri = zoo.GetClientServiceName() + ":" + strconv.Itoa(int(zkClientPort))
+	zkUri = zoo.GetClientServiceName() + "." + zoo.GetNamespace() + ".svc.cluster.local:" + strconv.Itoa(int(zkClientPort))
 	return zkUri
 }
 


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>


## Change log description
Changed the ZK URL as <zk-name>-client is not resolved by operator if both are in different namespaces.

## Purpose of the change
Fixes #139

## How to verify it
Verified deployment, scale up/down in default and other namespaces