### PR TITLE
Issue134: Support zookeeper cluster setup on minikube

### DIFF
--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -56,8 +56,20 @@ set +e
 nslookup $DOMAIN
 if [[ $? -eq 1 ]]; then
   # If an nslookup of the headless service domain fails, then there is no
-  # active ensemble yet
+  # active ensemble yet, but in certain cases nslookup of headless service
+  # takes a while to come up even if there is active ensemble
   ACTIVE_ENSEMBLE=false
+  declare -i count=20
+  while [[ $count -ge 0 && $MYID -ne 1 ]]
+  do
+    sleep 2
+    ((count=count-1))
+    nslookup $DOMAIN
+    if [[ $? -eq 0 ]]; then
+      ACTIVE_ENSEMBLE=true
+      break
+    fi
+  done
 else
   ACTIVE_ENSEMBLE=true
 fi


### PR DESCRIPTION
Signed-off-by: anisha.kj anisha.kj@dell.com

## Change log description
In  minikube setup, for zookeeper-1 pod headless service is taking a while to come up and due to that nslookup was failing.  Added polling mechanism to check head less service is active.

## Purpose of the change
Fixes #134 

## How to verify it
Verified multiple times in minikube setup and able to deploy zookeeper  with 3 replicas.