### PR TITLE
Issue 101: Zookeeper Operator upgrade fails because of readiness check in deploy file

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
-	"github.com/operator-framework/operator-sdk/pkg/ready"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/pravega/zookeeper-operator/pkg/apis"
 	"github.com/pravega/zookeeper-operator/pkg/controller"
@@ -79,14 +78,6 @@ func main() {
 
 	// Become the leader before proceeding
 	leader.Become(context.TODO(), "zookeeper-operator-lock")
-
-	r := ready.NewFileReady()
-	err = r.Set()
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-	defer r.Unset()
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})

--- a/deploy/all_ns/operator.yaml
+++ b/deploy/all_ns/operator.yaml
@@ -23,14 +23,6 @@ spec:
           command:
           - zookeeper-operator
           imagePullPolicy: Always
-          readinessProbe:
-            exec:
-              command:
-                - stat
-                - /tmp/operator-sdk-ready
-            initialDelaySeconds: 4
-            periodSeconds: 10
-            failureThreshold: 1
           env:
           - name: WATCH_NAMESPACE
             value: ""

--- a/deploy/default_ns/operator.yaml
+++ b/deploy/default_ns/operator.yaml
@@ -23,14 +23,6 @@ spec:
           command:
           - zookeeper-operator
           imagePullPolicy: Always
-          readinessProbe:
-            exec:
-              command:
-                - stat
-                - /tmp/operator-sdk-ready
-            initialDelaySeconds: 4
-            periodSeconds: 10
-            failureThreshold: 1
           env:
           - name: WATCH_NAMESPACE
             valueFrom:


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

Change log description
Removed the readiness probe check from operator

Purpose of the change
Fixes #101

What the code does
Readiness probe check was preventing zk-operator to perform an upgrade. New pod is not becoming leader waiting for the readiness probe success and readiness probe check is not succeeding until it became leader, thus resulting in deadlock
Removed the readiness probe check from
 deploy/all_ns/operator.yaml                                                                   
deploy/default_ns/operator.yaml
cmd/manager/main.go

How to verify it
Verified that able to upgrade operator versions.