### PR TITLE
Issue150: Helm chart should allow watch namespace to be passed in.

### DIFF
--- a/charts/zookeeper-operator/templates/operator.yaml
+++ b/charts/zookeeper-operator/templates/operator.yaml
@@ -25,9 +25,7 @@ spec:
         - zookeeper-operator
         env:
         - name: WATCH_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: "{{ .Values.watchNamespace }}"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -19,3 +19,8 @@ serviceAccount:
 # Whether to create custom resource
 crd:
   create: true
+
+#
+# Specifies which namespace the Operator should watch for new ClusterResource resources
+# Default: "" == Watch ALL namespaces
+watchNamespace: ""


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>
Change log description
Configured WATCH_NAMESPACE field in Helm charts.

Purpose of the change
Fixes #150

What the code does
Added new configuration param in values.yaml file, so that WATCH_NAMESPACE can be configured. Added new cluster roles in zookeeper-operator charts so that it can install zookeeper  in different name space ,other than the one in which operator is running.

How to verify it
Tried installing operator and zk in same and different namespace using charts.