### PR TITLE
Added imagePullSecrets to serviceAccount for images in a private registry

### DIFF
--- a/charts/zookeeper-operator/templates/service_account.yaml
+++ b/charts/zookeeper-operator/templates/service_account.yaml
@@ -1,6 +1,12 @@
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+{{- if .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.serviceAccount.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 metadata:
   name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}

--- a/charts/zookeeper-operator/templates/service_account.yaml
+++ b/charts/zookeeper-operator/templates/service_account.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
-{{- if .Values.serviceAccount.imagePullSecrets }}
+{{- if or .Values.global.imagePullSecrets .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
-{{- range .Values.serviceAccount.imagePullSecrets }}
+{{- range (default .Values.global.imagePullSecrets .Values.serviceAccount.imagePullSecrets) }}
   - name: {{ . }}
 {{- end }}
 {{- end }}

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -2,6 +2,10 @@
 ## This is a YAML-formatted file.
 ## Declare variables to be passed into your templates.
 
+global:
+  # Lists the secrets you need to use to pull zookeeper-operator image from a private registry.
+  imagePullSecrets: []
+  # - private-registry-key
 
 image:
   repository: pravega/zookeeper-operator
@@ -16,9 +20,8 @@ rbac:
 serviceAccount:
   create: true
   name: zookeeper-operator
-  # Lists the secrets you need to use to pull zookeeper-operator image from a private registry.
-  imagePullSecrets: []
-    # - private-registry-key
+  ## Optionally specify an array of imagePullSecrets. Will override the global parameter if set
+  # imagePullSecrets:
 
 ## Whether to create the CRD.
 crd:

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -2,6 +2,7 @@
 ## This is a YAML-formatted file.
 ## Declare variables to be passed into your templates.
 
+
 image:
   repository: pravega/zookeeper-operator
   tag: 0.2.7
@@ -15,6 +16,9 @@ rbac:
 serviceAccount:
   create: true
   name: zookeeper-operator
+  # Lists the secrets you need to use to pull zookeeper-operator image from a private registry.
+  imagePullSecrets: []
+    # - private-registry-key
 
 ## Whether to create the CRD.
 crd:


### PR DESCRIPTION
Adding the option `imagePullSecrets` inside the serviceAccount to allow for images in private registries. A list of secret names can be specified in `serviceAccount.imagePullSecrets`