### PR TITLE
Issue 162: Allow image string

### DIFF
--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -21,11 +21,13 @@ import (
 const (
 	// DefaultZkContainerRepository is the default docker repo for the zookeeper
 	// container
-	DefaultZkContainerRepository = "pravega/zookeeper"
+	//DefaultZkContainerRepository = "pravega/zookeeper"
 
 	// DefaultZkContainerVersion is the default tag used for for the zookeeper
 	// container
-	DefaultZkContainerVersion = "latest"
+	//DefaultZkContainerVersion = "latest"
+
+	DefaultZkImage = "pravega/zookeeper:latest"
 
 	// DefaultZkContainerPolicy is the default container pull policy used
 	DefaultZkContainerPolicy = "Always"
@@ -202,25 +204,15 @@ type Ports struct {
 // ContainerImage defines the fields needed for a Docker repository image. The
 // format here matches the predominant format used in Helm charts.
 type ContainerImage struct {
-	Repository string        `json:"repository"`
-	Tag        string        `json:"tag"`
-    Image      string        `json:"image"`
+	Image      string        `json:"image"`
 	PullPolicy v1.PullPolicy `json:"pullPolicy"`
 }
 
 func (c *ContainerImage) withDefaults() (changed bool) {
-	if c.Repository == "" {
+	if c.Image == "" {
 		changed = true
-		c.Repository = DefaultZkContainerRepository
+		c.Image = DefaultZkImage
 	}
-	if c.Tag == "" {
-		changed = true
-		c.Tag = DefaultZkContainerVersion
-	}
-    if c.Image == "" {
-        changed = true 
-        c.Image = c.Repository + ":" + c.Tag
-    }
 	if c.PullPolicy == "" {
 		changed = true
 		c.PullPolicy = DefaultZkContainerPolicy
@@ -231,8 +223,8 @@ func (c *ContainerImage) withDefaults() (changed bool) {
 // ToString formats a container image struct as a docker compatible repository
 // string.
 func (c *ContainerImage) ToString() string {
-    // return fmt.Sprintf("%s:%s", c.Repository, c.Tag)
-    return fmt.Sprintf("%s", c.Image)
+	// return fmt.Sprintf("%s:%s", c.Repository, c.Tag)
+	return fmt.Sprintf("%s", c.Image)
 }
 
 // PodPolicy defines the common pod configuration for Pods, including when used

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -204,6 +204,7 @@ type Ports struct {
 type ContainerImage struct {
 	Repository string        `json:"repository"`
 	Tag        string        `json:"tag"`
+    Image      string        `json:"image"`
 	PullPolicy v1.PullPolicy `json:"pullPolicy"`
 }
 
@@ -216,6 +217,10 @@ func (c *ContainerImage) withDefaults() (changed bool) {
 		changed = true
 		c.Tag = DefaultZkContainerVersion
 	}
+    if c.Image == "" {
+        changed = true 
+        c.Image = c.Repository + ":" + c.Tag
+    }
 	if c.PullPolicy == "" {
 		changed = true
 		c.PullPolicy = DefaultZkContainerPolicy
@@ -226,7 +231,8 @@ func (c *ContainerImage) withDefaults() (changed bool) {
 // ToString formats a container image struct as a docker compatible repository
 // string.
 func (c *ContainerImage) ToString() string {
-	return fmt.Sprintf("%s:%s", c.Repository, c.Tag)
+    // return fmt.Sprintf("%s:%s", c.Repository, c.Tag)
+    return fmt.Sprintf("%s", c.Image)
 }
 
 // PodPolicy defines the common pod configuration for Pods, including when used

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types_test.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types_test.go
@@ -69,16 +69,8 @@ var _ = Describe("ZookeeperCluster Types", func() {
 				i = z.Spec.Image
 			})
 
-			It("should have the default repo", func() {
-				Ω(i.Repository).To(Equal(v1beta1.DefaultZkContainerRepository))
-			})
-
-			It("should have the default tag", func() {
-				Ω(i.Tag).To(Equal(v1beta1.DefaultZkContainerVersion))
-			})
-
 			It("should have the default full image name", func() {
-                Ω(i.Image).To(Equal(v1beta1.DefaultZkContainerRepository + ":" + v1beta1.DefaultZkContainerVersion))
+				Ω(i.Image).To(Equal(v1beta1.DefaultZkImage))
 			})
 
 			It("should have the default policy", func() {

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types_test.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types_test.go
@@ -77,6 +77,10 @@ var _ = Describe("ZookeeperCluster Types", func() {
 				Ω(i.Tag).To(Equal(v1beta1.DefaultZkContainerVersion))
 			})
 
+			It("should have the default full image name", func() {
+                Ω(i.Image).To(Equal(v1beta1.DefaultZkContainerRepository + ":" + v1beta1.DefaultZkContainerVersion))
+			})
+
 			It("should have the default policy", func() {
 				Ω(i.PullPolicy).To(BeEquivalentTo(v1beta1.DefaultZkContainerPolicy))
 			})


### PR DESCRIPTION
Issue: #162 

Purpose is to change from the repository/tag style, to a pure image string, similar to how the operator does it.

Non working, not sure what needs to be changed to allow for 'image' to function as is.

Tests do pass, it does build, just doesn't seem to allow for the image to be passed in like I'd like it to be. Looking for some potential assistance?