### PR TITLE
added support for current version

### DIFF
--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -145,7 +145,7 @@ type ZookeeperClusterStatus struct {
 	// CurrentVersion is the current cluster version
 	CurrentVersion string `json:"currentVersion"`
 
-	//UpdateFlag indicate status of update
+	// UpdateFlag indicate if update of the cluster is in progress or not
 	UpdateFlag bool `json:"updateFlag"`
 }
 

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -141,6 +141,12 @@ type ZookeeperClusterStatus struct {
 	ExternalClientEndpoint string `json:"externalClientEndpoint"`
 
 	MetaRootCreated bool `json:"metaRootCreated"`
+
+	// CurrentVersion is the current cluster version
+	CurrentVersion string `json:"currentVersion"`
+
+	//UpdateFlag indicate status of update
+	UpdateFlag bool `json:"updateFlag"`
 }
 
 // MembersStatus is the status of the members of the cluster with both

--- a/pkg/controller/zookeepercluster/zookeepercluster_controller.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller.go
@@ -429,7 +429,7 @@ func (r *ReconcileZookeeperCluster) reconcileClusterStatus(instance *zookeeperv1
 		return err
 	}
 	//setting the updateflag is case of update of zookeepercluster
-	if instance.Status.CurrentVersion != instance.Spec.Image.Tag && foundSts.Status.UpdatedReplicas == 0 {
+	if !IsCurrentVersionEmpty(instance.Status.CurrentVersion) && instance.Status.CurrentVersion != instance.Spec.Image.Tag && foundSts.Status.UpdatedReplicas != *foundSts.Spec.Replicas {
 		instance.Status.UpdateFlag = true
 	}
 	//setting the currentVersion


### PR DESCRIPTION
Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>
### Change log description
This PR introduces the CurrentVersion field and sets the CurrentVersion field to the zookeeper cluster image tag deployed by the zookeeper operator 

### Purpose of the change
To display the current version as part of the status field of the zookeeper cluster

### What the code does
It sets the value of the current version in case of the fresh deployment of the zookeeper cluster it also sets the current version when the image tag of the zookeeper cluster is updated and the update is completed

### How to verify it
1) Deploy a Zookeeper cluster and after all the replicas have been deployed the  CurrentVersion 
    field  in the status of zookeeper cluster will show the current image tag deployed by the 
    zookeeper operator.
2) Update  the image tag in the zookeeper cluster and when all the pods have been updated 
    CurrentVersion field will display the new image tag for the zookeeper cluster.