### PR TITLE
Issue 171: Create PVCs in cluster namespace

### DIFF
--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -76,6 +76,7 @@ func MakeStatefulSet(z *v1beta1.ZookeeperCluster) *appsv1.StatefulSet {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "data",
+						Namespace: z.Namespace,
 						Labels: map[string]string{"app": z.GetName()},
 					},
 					Spec: z.Spec.Persistence.PersistentVolumeClaimSpec,

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -75,9 +75,9 @@ func MakeStatefulSet(z *v1beta1.ZookeeperCluster) *appsv1.StatefulSet {
 			VolumeClaimTemplates: []v1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:   "data",
+						Name:      "data",
 						Namespace: z.Namespace,
-						Labels: map[string]string{"app": z.GetName()},
+						Labels:    map[string]string{"app": z.GetName()},
 					},
 					Spec: z.Spec.Persistence.PersistentVolumeClaimSpec,
 				},


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
While creating the VolumeClaimTemplates for the Zookkeeper StatefulSet, the namespace of these PVCs is not explicitly set to that of the Zookkeeper Cluster.

### Purpose of the change
Fixes #171 

### What the code does
Creates Zookkeeper VolumeClaimTemplates in the same namespace as the Zookkeeper Cluster

### How to verify it
Created the zookeeper cluster in the namespace `new`.
Verified that the PVC is created in the same namespace as the zookeeper cluster
```
$ kubectl describe pvc data-zookeeper-0 -n new
Name:          data-zookeeper-0
Namespace:     new
StorageClass:  standard
Status:        Bound
Volume:        pvc-6b0f1880-550c-4f5c-8468-89a0ab1fdee9
Labels:        app=zookeeper
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/vsphere-volume
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      20Gi
Access Modes:  RWO
VolumeMode:    Filesystem
```