### PR TITLE
Issue-169 Add version info to Zookeeper Cluster CR status

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ example   3          3                 0.2.7     0.2.7             10.100.200.18
 ```
 >Note: when the Version field is set as well as Ready Replicas are equal to Replicas that signifies our cluster is in Ready state
 
-Additionally, check the output of describe command which should show the following cluster condition:-
+Additionally, check the output of describe command which should show the following cluster condition
 
 ```
 $ kubectl describe zk
@@ -139,7 +139,7 @@ To initiate an upgrade process, a user has to update the `spec.image.tag` field 
 
 After the `tag` field is updated, the StatefulSet will detect the version change and it will trigger the upgrade process.
 
-To detect whether a `ZookeeperCluster` upgrade is in progress or not, check the output of the command `kubectl describe zk`. Output of this command should contain the following entries:-
+To detect whether a `ZookeeperCluster` upgrade is in progress or not, check the output of the command `kubectl describe zk`. Output of this command should contain the following entries
 
 ```
 $ kubectl describe zk
@@ -164,7 +164,7 @@ NAME         REPLICAS   READY REPLICAS   VERSION   DESIRED VERSION   INTERNAL EN
 example        3          3                0.2.6     0.2.7             10.100.200.126:2181   N/A                 11m
 
 ```
-Once, the Upgrade completes, output for `$ kubectl get zk` command will have the Version as the Image tag it's supposed to upgrade to, as shown below :-
+Once, the Upgrade completes, output for `$ kubectl get zk` command will have the Version field set as he Desired Version, as shown below
 
 ```
 $ kubectl get zk
@@ -174,7 +174,7 @@ example        3          3               0.2.7     0.2.7            10.100.200.
 
 
 ```
-Additionally, the describe output will have the Upgrading status set to False and PodsReady status set to True which signifies that the upgrade has completed, as shown below :-
+Additionally, the describe output will have the Upgrading status set to False and PodsReady status set to True which signifies that the upgrade has completed, as shown below
 
 ```
 $ kubectl describe zk

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ example        3          3               0.2.7     0.2.7            10.100.200.
 
 
 ```
-Additionally, the Upgrading status set to False and PodsReady status set to True, which signifies that the upgrade has completed, as shown below
+Additionally, the Upgrading status is set to False and PodsReady status is set to True, which signifies that the upgrade has completed, as shown below
 
 ```
 $ kubectl describe zk

--- a/README.md
+++ b/README.md
@@ -99,19 +99,19 @@ NAME      AGE
 example   15s
 ```
 
-```
 After a couple of minutes, all cluster members should become ready.
 
+```
 $ kubectl get zookeepercluster
 
 NAME      REPLICAS   READY REPLICAS   VERSION   DESIRED VERSION   INTERNAL ENDPOINT    EXTERNAL ENDPOINT   AGE
 example   3          3                latest                      10.100.200.18:2181   N/A                 94s
-
+```
 Note: when the Version field is set as well as Ready Replicas are equal to Replicas that signifies our cluster is in Ready state
-```
-```
+
 Additionally, check the output of describe command which should show the following cluster condition:-
 
+```
 $ kubectl describe zookeepercluster
 
 Conditions:
@@ -120,8 +120,8 @@ Conditions:
   Status:                  True
   Type:                    PodsReady
 
-Note: User should wait for the Pods Ready condition to be True
 ```
+Note: User should wait for the Pods Ready condition to be True
 
 ```
 $ kubectl get all -l app=example
@@ -147,7 +147,7 @@ To initiate an upgrade process, a user has to update the `spec.image.tag` field 
 
 After the `tag` field is updated, the StatefulSet will detect the version change and it will trigger the upgrade process.
 
-To detect whether a `ZookeeperCluster` upgrade is in progress or not, check the output of the command `kubectl describe zookeepercluster`. The output of this command contains the following entries
+To detect whether a `ZookeeperCluster` upgrade is in progress or not, check the output of the command `kubectl describe zookeepercluster`. Output of this command should contain the following entries:-
 
 ```
 $ kubectl describe zookeepercluster
@@ -161,9 +161,9 @@ Status:                  True
 Type:                    Upgrading
 ```
 
-If the values of the fields `Status` field for clustercondition type `Upgrading` is True it signifies that the cluster is in Upgrading state
+If the Status value for clustercondition type `Upgrading` is True, it signifies that the cluster is in Upgrading state.
 
-Additionally, The output for the `$ kubectl get zookeepercluster ` will also have the Desired version set to the version the zookeepercluster is to be upgraded to.
+Additionally, The output for the `$ kubectl get zookeepercluster ` will also have the Desired version set to the Image Tag the zookeepercluster is trying to Upgrade to.
 
 ```
 $ kubectl get zookeepercluster
@@ -172,7 +172,7 @@ NAME         REPLICAS   READY REPLICAS   VERSION   DESIRED VERSION   INTERNAL EN
 example        3          3                0.2.6     0.2.5             10.100.200.126:2181   N/A                 11m
 
 ```
-Once, the Upgrade completes, The output for the `$ kubectl get zookeepercluster` will have the Version as the Image tag it's suppose to upgrade to and Desired Version will be empty
+Once, the Upgrade completes, The output for the `$ kubectl get zookeepercluster` will have the Version as the Image tag it's suppose to upgrade to and Desired Version will be empty. As shown Below:-
 
 ```
 $ kubectl get zookeepercluster
@@ -183,7 +183,7 @@ example        3          3                0.2.5                       10.100.20
 
 ```
 
-Additionally, output of the Describe command will have the upgrade condition set to false and Pods Ready condition set to True
+Additionally, output of the Describe command will have the `Upgrading` Status set to False and `PodsReady` status set to True. Which signifies upgrade is completed. As shown Below :-
 
 ```
 $ kubectl describe zookeepercluster

--- a/README.md
+++ b/README.md
@@ -152,19 +152,16 @@ Reason:                  Updating Zookeeper
 Status:                  True
 Type:                    Upgrading
 ```
-
-If the Status value for clustercondition type `Upgrading` is True, it signifies that the cluster is in Upgrading state.
-
-Additionally, The output for the `$ kubectl get zk` will also have the Desired version set to the Image Tag the zookeepercluster is trying to Upgrade to.
+Additionally, the Desired Version will be set to the version that we are upgrading our cluster to.
 
 ```
 $ kubectl get zk
 
 NAME         REPLICAS   READY REPLICAS   VERSION   DESIRED VERSION   INTERNAL ENDPOINT     EXTERNAL ENDPOINT   AGE
-example        3          3                0.2.6     0.2.7             10.100.200.126:2181   N/A                 11m
+example       3          3                0.2.6     0.2.7             10.100.200.126:2181   N/A                 11m
 
 ```
-Once, the Upgrade completes, output for `$ kubectl get zk` command will have the Version field set as he Desired Version, as shown below
+Once the upgrade completes, the Version field is set to the Desired Version, as shown below
 
 ```
 $ kubectl get zk
@@ -174,7 +171,7 @@ example        3          3               0.2.7     0.2.7            10.100.200.
 
 
 ```
-Additionally, the describe output will have the Upgrading status set to False and PodsReady status set to True which signifies that the upgrade has completed, as shown below
+Additionally, the Upgrading status set to False and PodsReady status set to True, which signifies that the upgrade has completed, as shown below
 
 ```
 $ kubectl describe zk

--- a/README.md
+++ b/README.md
@@ -91,28 +91,20 @@ spec:
 $ kubectl create -f zk.yaml
 ```
 
-Verify that the cluster instances and its components are running.
-
-```
-$ kubectl get zk
-NAME      AGE
-example   15s
-```
-
 After a couple of minutes, all cluster members should become ready.
 
 ```
-$ kubectl get zookeepercluster
+$ kubectl get zk
 
 NAME      REPLICAS   READY REPLICAS   VERSION   DESIRED VERSION   INTERNAL ENDPOINT    EXTERNAL ENDPOINT   AGE
-example   3          3                latest                      10.100.200.18:2181   N/A                 94s
+example   3          3                 0.2.7     0.2.7             10.100.200.18:2181   N/A                 94s
 ```
-Note: when the Version field is set as well as Ready Replicas are equal to Replicas that signifies our cluster is in Ready state
+>Note: when the Version field is set as well as Ready Replicas are equal to Replicas that signifies our cluster is in Ready state
 
 Additionally, check the output of describe command which should show the following cluster condition:-
 
 ```
-$ kubectl describe zookeepercluster
+$ kubectl describe zk
 
 Conditions:
   Last Transition Time:    2020-05-18T10:17:03Z
@@ -121,7 +113,7 @@ Conditions:
   Type:                    PodsReady
 
 ```
-Note: User should wait for the Pods Ready condition to be True
+>Note: User should wait for the Pods Ready condition to be True
 
 ```
 $ kubectl get all -l app=example
@@ -147,10 +139,10 @@ To initiate an upgrade process, a user has to update the `spec.image.tag` field 
 
 After the `tag` field is updated, the StatefulSet will detect the version change and it will trigger the upgrade process.
 
-To detect whether a `ZookeeperCluster` upgrade is in progress or not, check the output of the command `kubectl describe zookeepercluster`. Output of this command should contain the following entries:-
+To detect whether a `ZookeeperCluster` upgrade is in progress or not, check the output of the command `kubectl describe zk`. Output of this command should contain the following entries:-
 
 ```
-$ kubectl describe zookeepercluster
+$ kubectl describe zk
 
 status:
 Last Transition Time:    2020-05-18T10:25:12Z
@@ -163,30 +155,29 @@ Type:                    Upgrading
 
 If the Status value for clustercondition type `Upgrading` is True, it signifies that the cluster is in Upgrading state.
 
-Additionally, The output for the `$ kubectl get zookeepercluster ` will also have the Desired version set to the Image Tag the zookeepercluster is trying to Upgrade to.
+Additionally, The output for the `$ kubectl get zk` will also have the Desired version set to the Image Tag the zookeepercluster is trying to Upgrade to.
 
 ```
-$ kubectl get zookeepercluster
+$ kubectl get zk
 
 NAME         REPLICAS   READY REPLICAS   VERSION   DESIRED VERSION   INTERNAL ENDPOINT     EXTERNAL ENDPOINT   AGE
-example        3          3                0.2.6     0.2.5             10.100.200.126:2181   N/A                 11m
+example        3          3                0.2.6     0.2.7             10.100.200.126:2181   N/A                 11m
 
 ```
-Once, the Upgrade completes, The output for the `$ kubectl get zookeepercluster` will have the Version as the Image tag it's suppose to upgrade to and Desired Version will be empty. As shown Below:-
+Once, the Upgrade completes, output for `$ kubectl get zk` command will have the Version as the Image tag it's supposed to upgrade to, as shown below :-
 
 ```
-$ kubectl get zookeepercluster
+$ kubectl get zk
 
 NAME         REPLICAS   READY REPLICAS   VERSION   DESIRED VERSION   INTERNAL ENDPOINT     EXTERNAL ENDPOINT   AGE
-example        3          3                0.2.5                       10.100.200.126:2181   N/A                 11m
+example        3          3               0.2.7     0.2.7            10.100.200.126:2181   N/A                 11m
 
 
 ```
-
-Additionally, output of the Describe command will have the `Upgrading` Status set to False and `PodsReady` status set to True. Which signifies upgrade is completed. As shown Below :-
+Additionally, the describe output will have the Upgrading status set to False and PodsReady status set to True which signifies that the upgrade has completed, as shown below :-
 
 ```
-$ kubectl describe zookeepercluster
+$ kubectl describe zk
 
 Status:
   Conditions:
@@ -199,10 +190,7 @@ Status:
     Status:                  False
     Type:                    Upgrading
 ```
-
-```
-Note: The value of the tag field should not be modified while an upgrade is already in progress.
-```
+>Note: The value of the tag field should not be modified while an upgrade is already in progress.
 
 ### Uninstall the Zookeeper cluster
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ $ kubectl get zookeepercluster
 NAME      REPLICAS   READY REPLICAS   VERSION   DESIRED VERSION   INTERNAL ENDPOINT    EXTERNAL ENDPOINT   AGE
 example   3          3                latest                      10.100.200.18:2181   N/A                 94s
 
-Note = when the Version field is set as well as Ready Replicas are equal to Replicas that signifies our cluster is in Ready state
+Note: when the Version field is set as well as Ready Replicas are equal to Replicas that signifies our cluster is in Ready state
 ```
 ```
-Additionally check the output of describecommand should show the following cluster condition:-
+Additionally, check the output of describe command which should show the following cluster condition:-
 
 $ kubectl describe zookeepercluster
 
@@ -120,8 +120,9 @@ Conditions:
   Status:                  True
   Type:                    PodsReady
 
-Note = User should wait for the Pods Ready condition to be True for the Zookeeper Cluster
+Note: User should wait for the Pods Ready condition to be True
 ```
+
 ```
 $ kubectl get all -l app=example
 NAME                   DESIRED   CURRENT   AGE
@@ -182,7 +183,7 @@ example        3          3                0.2.5                       10.100.20
 
 ```
 
-Additionally output of the Describe command will have the upgrade condition set to false and Pods Ready condition set to True
+Additionally, output of the Describe command will have the upgrade condition set to false and Pods Ready condition set to True
 
 ```
 $ kubectl describe zookeepercluster

--- a/deploy/crds/zookeeper_v1beta1_zookeepercluster_cr.yaml
+++ b/deploy/crds/zookeeper_v1beta1_zookeepercluster_cr.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 3
   image:
     repository: pravega/zookeeper
-    tag: latest
+    tag: 0.2.7
   persistence:
     accessModes: [ "ReadWriteOnce" ]
     storageClassName: "standard"

--- a/deploy/crds/zookeeper_v1beta1_zookeepercluster_crd.yaml
+++ b/deploy/crds/zookeeper_v1beta1_zookeepercluster_crd.yaml
@@ -20,6 +20,14 @@ spec:
     type: integer
     description: The number of ZooKeeper servers in the ensemble that are in a Ready state
     JSONPath: .status.readyReplicas
+  - name: version
+    type: string
+    description: The current Zookeeper version
+    JSONPath: .status.currentVersion
+  - name: Desired version
+    type: string
+    description: The desired Zookeeper version
+    JSONPath: .status.targetVersion    
   - name: Internal Endpoint
     type: string
     description: Client endpoint internal to cluster network

--- a/deploy/crds/zookeeper_v1beta1_zookeepercluster_crd.yaml
+++ b/deploy/crds/zookeeper_v1beta1_zookeepercluster_crd.yaml
@@ -27,7 +27,7 @@ spec:
   - name: Desired version
     type: string
     description: The desired Zookeeper version
-    JSONPath: .status.targetVersion    
+    JSONPath: .spec.image.tag    
   - name: Internal Endpoint
     type: string
     description: Client endpoint internal to cluster network

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go v0.55.0
 	github.com/PuerkitoBio/purell v1.1.1
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+	github.com/alecthomas/gocyclo v0.0.0-20150208221726-aa8f8b160214 // indirect
 	github.com/beorn7/perks v1.0.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/emicklei/go-restful v2.12.0+incompatible
@@ -29,6 +30,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hpcloud/tail v1.0.0
 	github.com/imdario/mergo v0.3.8
+	github.com/jgautheron/goconst v0.0.0-20200227150835-cda7ea3bf591 // indirect
 	github.com/json-iterator/go v1.1.9
 	github.com/mailru/easyjson v0.7.1
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/prometheus/common v0.9.1
 	github.com/prometheus/procfs v0.0.11
 	github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da
+	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/atomic v1.6.0
 	go.uber.org/multierr v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.13
 
 require (
 	4d63.com/gochecknoglobals v0.0.0-20190306162314-7c3491d2b6ec // indirect
+	4d63.com/gochecknoinits v0.0.0-20200108094044-eb73b47b9fc4 // indirect
 	cloud.google.com/go v0.55.0
 	github.com/PuerkitoBio/purell v1.1.1
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 	github.com/alecthomas/gocyclo v0.0.0-20150208221726-aa8f8b160214 // indirect
+	github.com/alexkohler/nakedret v1.0.0 // indirect
 	github.com/beorn7/perks v1.0.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/emicklei/go-restful v2.12.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -37,11 +37,13 @@ require (
 	github.com/mailru/easyjson v0.7.1
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a
 	github.com/matttproud/golang_protobuf_extensions v1.0.1
+	github.com/mdempsky/maligned v0.0.0-20180708014732-6e39bd26a8c8 // indirect
 	github.com/mdempsky/unconvert v0.0.0-20200228143138-95ecdbfc0b5f // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 	github.com/modern-go/reflect2 v1.0.1
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
+	github.com/opennota/check v0.0.0-20180911053232-0c771f5545ff // indirect
 	github.com/operator-framework/operator-sdk v0.3.0
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709
 	github.com/petar/GoLLRB v0.0.0-20190514000832-33fb24c13b99
@@ -54,6 +56,7 @@ require (
 	github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5
+	github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9 // indirect
 	go.uber.org/atomic v1.6.0
 	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.14.1
@@ -64,7 +67,7 @@ require (
 	golang.org/x/sys v0.0.0-20200320181252-af34d8274f85
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
-	golang.org/x/tools v0.0.0-20200321014904-268ba720d32c
+	golang.org/x/tools v0.0.0-20200426102838-f3a5411a4c3b
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	google.golang.org/appengine v1.6.5
 	gopkg.in/inf.v0 v0.9.1
@@ -77,5 +80,8 @@ require (
 	k8s.io/gengo v0.0.0-20200205140755-e0e292d8aa12
 	k8s.io/klog v1.0.0
 	k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe
+	mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed // indirect
+	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
+	mvdan.cc/unparam v0.0.0-20200501210554-b37ab49443f7 // indirect
 	sigs.k8s.io/controller-runtime v0.1.8
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pravega/zookeeper-operator
 go 1.13
 
 require (
+	4d63.com/gochecknoglobals v0.0.0-20190306162314-7c3491d2b6ec // indirect
 	cloud.google.com/go v0.55.0
 	github.com/PuerkitoBio/purell v1.1.1
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
@@ -26,6 +27,7 @@ require (
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.4.0
+	github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hpcloud/tail v1.0.0
@@ -35,6 +37,7 @@ require (
 	github.com/mailru/easyjson v0.7.1
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a
 	github.com/matttproud/golang_protobuf_extensions v1.0.1
+	github.com/mdempsky/unconvert v0.0.0-20200228143138-95ecdbfc0b5f // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 	github.com/modern-go/reflect2 v1.0.1
 	github.com/onsi/ginkgo v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+4d63.com/gochecknoglobals v0.0.0-20190306162314-7c3491d2b6ec h1:LArU+LLj2RRPagtrxuBE+xs+zJzOCWvX99TIoGac1gE=
+4d63.com/gochecknoglobals v0.0.0-20190306162314-7c3491d2b6ec/go.mod h1:Sk40JNJmh0koZukOjJfaBNLZazbZthFfHnLHIcZNS6A=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -129,6 +131,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.4.0 h1:BXDUo8p/DaxC+4FJY/SSx3gvnx9C1VdHNgaUkiEL5mk=
 github.com/googleapis/gnostic v0.4.0/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
+github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf h1:vc7Dmrk4JwS0ZPS6WZvWlwDflgDTA26jItmbSj83nug=
+github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -164,6 +168,8 @@ github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a h1:+J2gw7Bw77w
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mdempsky/unconvert v0.0.0-20200228143138-95ecdbfc0b5f h1:Kc3s6QFyh9DLgInXpWKuG+8I7R7lXbnP7mcoOVIt6KY=
+github.com/mdempsky/unconvert v0.0.0-20200228143138-95ecdbfc0b5f/go.mod h1:AmCV4WB3cDMZqgPk+OUQKumliiQS4ZYsBt3AXekyuAU=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -380,7 +386,9 @@ golang.org/x/tools v0.0.0-20200204074204-1cc6d1ef6c74/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200225230052-807dcd883420/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200317043434-63da46f3035e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
+golang.org/x/tools v0.0.0-20200321014904-268ba720d32c h1:Qp5jXmUCqMiVq4676uW7bY2oskIR1ivTboSMn8qgeX0=
 golang.org/x/tools v0.0.0-20200321014904-268ba720d32c/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/alecthomas/gocyclo v0.0.0-20150208221726-aa8f8b160214 h1:YI/8G3uLbYyowJeOPVL6BMKe2wbL54h0FdEKmncU6lU=
+github.com/alecthomas/gocyclo v0.0.0-20150208221726-aa8f8b160214/go.mod h1:Ef5UOtJdJ5rVFObdOVsrNgKV/Wf4I+daTCSk8GTrHIk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -138,6 +140,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/jgautheron/goconst v0.0.0-20200227150835-cda7ea3bf591 h1:x/BpEhm6aL26o4TLtcU0loJ7B3+69jielrGc70V7Yb4=
+github.com/jgautheron/goconst v0.0.0-20200227150835-cda7ea3bf591/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -146,6 +150,7 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -186,6 +191,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.4/go.mod h1:oCXIBxdI62A4cR6aTRJCgetEjecSIYzOEaeAn4iYEpM=
@@ -216,6 +222,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,7 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
+github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -168,6 +169,8 @@ github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a h1:+J2gw7Bw77w
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mdempsky/maligned v0.0.0-20180708014732-6e39bd26a8c8 h1:zvpKif6gkrh82wAd2JIffdLyCL52N8r+ABwHxdIOvWM=
+github.com/mdempsky/maligned v0.0.0-20180708014732-6e39bd26a8c8/go.mod h1:oGVD62YTpMEWw0JqJ2Vl48dzHywJBMlapkfsmhtokOU=
 github.com/mdempsky/unconvert v0.0.0-20200228143138-95ecdbfc0b5f h1:Kc3s6QFyh9DLgInXpWKuG+8I7R7lXbnP7mcoOVIt6KY=
 github.com/mdempsky/unconvert v0.0.0-20200228143138-95ecdbfc0b5f/go.mod h1:AmCV4WB3cDMZqgPk+OUQKumliiQS4ZYsBt3AXekyuAU=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -186,6 +189,8 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
+github.com/opennota/check v0.0.0-20180911053232-0c771f5545ff h1:lRHufowVGvUvxGsPveAZOpSa/9T5Gpxg6d7UbHCA9MQ=
+github.com/opennota/check v0.0.0-20180911053232-0c771f5545ff/go.mod h1:tydB+MZxWpY8M/NRu7jQhND/mXuLAPsKcSV6JkzofsA=
 github.com/operator-framework/operator-sdk v0.3.0 h1:MHBAwot3D4ssTwnlemupOkLNIj/Ohjfy/nF/zDRg1gA=
 github.com/operator-framework/operator-sdk v0.3.0/go.mod h1:iVyukRkam5JZa8AnjYf+/G3rk7JI1+M6GsU0sq0B9NA=
 github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 h1:zNBQb37RGLmJybyMcs983HfUfpkw9OTFD9tbBfAViHE=
@@ -216,6 +221,7 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.11 h1:DhHlBtkHWPYi8O2y31JkK0TF+DGM+51OopZjH/Ia5qI=
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.5.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da h1:p3Vo3i64TCLY7gIfzeQaUJ+kppEO5WQG3cL8iE8tGHU=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -230,7 +236,10 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9 h1:vY5WqiEon0ZSTGM3ayVVi+twaHKHDFUVloaQ/wug9/c=
+github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9/go.mod h1:q+QjxYvZ+fpjMXqs+XEriussHjSYqeXVnAdSV1tkMYk=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -390,6 +399,8 @@ golang.org/x/tools v0.0.0-20200225230052-807dcd883420/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200317043434-63da46f3035e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200321014904-268ba720d32c h1:Qp5jXmUCqMiVq4676uW7bY2oskIR1ivTboSMn8qgeX0=
 golang.org/x/tools v0.0.0-20200321014904-268ba720d32c/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
+golang.org/x/tools v0.0.0-20200426102838-f3a5411a4c3b h1:zSzQJAznWxAh9fZxiPy2FZo+ZZEYoYFYYDYdOrU7AaM=
+golang.org/x/tools v0.0.0-20200426102838-f3a5411a4c3b/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
@@ -439,6 +450,7 @@ google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKa
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
@@ -470,6 +482,12 @@ k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUc
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe h1:GOfbcWvX5wW2vcfNch83xYp9SDZjRgAJk+t373yaHKk=
 k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
+mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed h1:WX1yoOaKQfddO/mLzdV4wptyWgoH/6hwLs7QHTixo0I=
+mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
+mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b h1:DxJ5nJdkhDlLok9K6qO+5290kphDJbHOQO1DFFFTeBo=
+mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
+mvdan.cc/unparam v0.0.0-20200501210554-b37ab49443f7 h1:kAREL6MPwpsk1/PQPFD3Eg7WAQR5mPTWZJaBiG5LDbY=
+mvdan.cc/unparam v0.0.0-20200501210554-b37ab49443f7/go.mod h1:HGC5lll35J70Y5v7vCGb9oLhHoScFwkHDJm/05RdSTc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 4d63.com/gochecknoglobals v0.0.0-20190306162314-7c3491d2b6ec h1:LArU+LLj2RRPagtrxuBE+xs+zJzOCWvX99TIoGac1gE=
 4d63.com/gochecknoglobals v0.0.0-20190306162314-7c3491d2b6ec/go.mod h1:Sk40JNJmh0koZukOjJfaBNLZazbZthFfHnLHIcZNS6A=
+4d63.com/gochecknoinits v0.0.0-20200108094044-eb73b47b9fc4 h1:bf5qocEKjrY58JO2GwywfLsb1199lIVs7qHkiplwHy0=
+4d63.com/gochecknoinits v0.0.0-20200108094044-eb73b47b9fc4/go.mod h1:4o1i5aXtIF5tJFt3UD1knCVmWOXg7fLYdHVu6jeNcnM=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -37,6 +39,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alexkohler/nakedret v1.0.0 h1:S/bzOFhZHYUJp6qPmdXdFHS5nlWGFmLmoc8QOydvotE=
+github.com/alexkohler/nakedret v1.0.0/go.mod h1:tfDQbtPt67HhBK/6P0yNktIX7peCxfOp0jO9007DrLE=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,7 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da h1:p3Vo3i64TCLY7gIfzeQaUJ+kppEO5WQG3cL8iE8tGHU=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/pkg/apis/zookeeper/v1beta1/status.go
+++ b/pkg/apis/zookeeper/v1beta1/status.go
@@ -216,6 +216,6 @@ func (zs *ZookeeperClusterStatus) GetLastCondition() (lastCondition *ClusterCond
 		_, lastCondition := zs.GetClusterCondition(ClusterConditionUpgrading)
 		return lastCondition
 	}
-	// nothing to do if we are not upgrading,
+	// nothing to do if we are not upgrading
 	return nil
 }

--- a/pkg/apis/zookeeper/v1beta1/status.go
+++ b/pkg/apis/zookeeper/v1beta1/status.go
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package v1beta1
+
+import (
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type ClusterConditionType string
+
+const (
+	ClusterConditionPodsReady ClusterConditionType = "PodsReady"
+	ClusterConditionUpgrading                      = "Upgrading"
+	ClusterConditionError                          = "Error"
+
+	// Reasons for cluster upgrading condition
+	UpdatingZookeeperReason = "Updating Zookeeper"
+	UpgradeErrorReason      = "Upgrade Error"
+)
+
+// ZookeeperClusterStatus defines the observed state of ZookeeperCluster
+type ZookeeperClusterStatus struct {
+	// Members is the zookeeper members in the cluster
+	Members MembersStatus `json:"members"`
+
+	// Replicas is the number of number of desired replicas in the cluster
+	Replicas int32 `json:"replicas"`
+
+	// ReadyReplicas is the number of number of ready replicas in the cluster
+	ReadyReplicas int32 `json:"readyReplicas"`
+
+	// InternalClientEndpoint is the internal client IP and port
+	InternalClientEndpoint string `json:"internalClientEndpoint"`
+
+	// ExternalClientEndpoint is the internal client IP and port
+	ExternalClientEndpoint string `json:"externalClientEndpoint"`
+
+	MetaRootCreated bool `json:"metaRootCreated"`
+
+	// CurrentVersion is the current cluster version
+	CurrentVersion string `json:"currentVersion"`
+
+	TargetVersion string `json:"targetVersion"`
+
+	// Conditions list all the applied conditions
+	Conditions []ClusterCondition `json:"conditions,omitempty"`
+}
+
+// MembersStatus is the status of the members of the cluster with both
+// ready and unready node membership lists
+type MembersStatus struct {
+	Ready   []string `json:"ready"`
+	Unready []string `json:"unready"`
+}
+
+// ClusterCondition shows the current condition of a Zookeeper cluster.
+// Comply with k8s API conventions
+type ClusterCondition struct {
+	// Type of Zookeeper cluster condition.
+	Type ClusterConditionType `json:"type"`
+
+	// Status of the condition, one of True, False, Unknown.
+	Status v1.ConditionStatus `json:"status"`
+
+	// The reason for the condition's last transition.
+	Reason string `json:"reason,omitempty"`
+
+	// A human readable message indicating details about the transition.
+	Message string `json:"message,omitempty"`
+
+	// The last time this condition was updated.
+	LastUpdateTime string `json:"lastUpdateTime,omitempty"`
+
+	// Last time the condition transitioned from one status to another.
+	LastTransitionTime string `json:"lastTransitionTime,omitempty"`
+}
+
+func (zs *ZookeeperClusterStatus) Init() {
+	// Initialise conditions
+	conditionTypes := []ClusterConditionType{
+		ClusterConditionPodsReady,
+		ClusterConditionUpgrading,
+		ClusterConditionError,
+	}
+	for _, conditionType := range conditionTypes {
+		if _, condition := zs.GetClusterCondition(conditionType); condition == nil {
+			c := newClusterCondition(conditionType, v1.ConditionFalse, "", "")
+			zs.setClusterCondition(*c)
+		}
+	}
+}
+
+func newClusterCondition(condType ClusterConditionType, status v1.ConditionStatus, reason, message string) *ClusterCondition {
+	return &ClusterCondition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastUpdateTime:     "",
+		LastTransitionTime: "",
+	}
+}
+
+func (zs *ZookeeperClusterStatus) SetPodsReadyConditionTrue() {
+	c := newClusterCondition(ClusterConditionPodsReady, v1.ConditionTrue, "", "")
+	zs.setClusterCondition(*c)
+}
+
+func (zs *ZookeeperClusterStatus) SetPodsReadyConditionFalse() {
+	c := newClusterCondition(ClusterConditionPodsReady, v1.ConditionFalse, "", "")
+	zs.setClusterCondition(*c)
+}
+
+func (zs *ZookeeperClusterStatus) SetUpgradingConditionTrue(reason, message string) {
+	c := newClusterCondition(ClusterConditionUpgrading, v1.ConditionTrue, reason, message)
+	zs.setClusterCondition(*c)
+}
+
+func (zs *ZookeeperClusterStatus) SetUpgradingConditionFalse() {
+	c := newClusterCondition(ClusterConditionUpgrading, v1.ConditionFalse, "", "")
+	zs.setClusterCondition(*c)
+}
+
+func (zs *ZookeeperClusterStatus) SetErrorConditionTrue(reason, message string) {
+	c := newClusterCondition(ClusterConditionError, v1.ConditionTrue, reason, message)
+	zs.setClusterCondition(*c)
+}
+
+func (zs *ZookeeperClusterStatus) SetErrorConditionFalse() {
+	c := newClusterCondition(ClusterConditionError, v1.ConditionFalse, "", "")
+	zs.setClusterCondition(*c)
+}
+
+func (zs *ZookeeperClusterStatus) GetClusterCondition(t ClusterConditionType) (int, *ClusterCondition) {
+	for i, c := range zs.Conditions {
+		if t == c.Type {
+			return i, &c
+		}
+	}
+	return -1, nil
+}
+
+func (zs *ZookeeperClusterStatus) setClusterCondition(newCondition ClusterCondition) {
+	now := time.Now().Format(time.RFC3339)
+	position, existingCondition := zs.GetClusterCondition(newCondition.Type)
+
+	if existingCondition == nil {
+		zs.Conditions = append(zs.Conditions, newCondition)
+		return
+	}
+
+	if existingCondition.Status != newCondition.Status {
+		existingCondition.Status = newCondition.Status
+		existingCondition.LastTransitionTime = now
+		existingCondition.LastUpdateTime = now
+	}
+
+	if existingCondition.Reason != newCondition.Reason || existingCondition.Message != newCondition.Message {
+		existingCondition.Reason = newCondition.Reason
+		existingCondition.Message = newCondition.Message
+		existingCondition.LastUpdateTime = now
+	}
+
+	zs.Conditions[position] = *existingCondition
+}
+
+func (zs *ZookeeperClusterStatus) IsClusterInUpgradeFailedState() bool {
+	_, errorCondition := zs.GetClusterCondition(ClusterConditionError)
+	if errorCondition == nil {
+		return false
+	}
+	if errorCondition.Status == v1.ConditionTrue && errorCondition.Reason == "UpgradeFailed" {
+		return true
+	}
+	return false
+}
+
+func (zs *ZookeeperClusterStatus) IsClusterInUpgradingState() bool {
+	_, upgradeCondition := zs.GetClusterCondition(ClusterConditionUpgrading)
+	if upgradeCondition == nil {
+		return false
+	}
+	if upgradeCondition.Status == v1.ConditionTrue {
+		return true
+	}
+	return false
+}
+
+func (zs *ZookeeperClusterStatus) IsClusterInReadyState() bool {
+	_, readyCondition := zs.GetClusterCondition(ClusterConditionPodsReady)
+	if readyCondition != nil && readyCondition.Status == v1.ConditionTrue {
+		return true
+	}
+	return false
+}
+
+func (zs *ZookeeperClusterStatus) UpdateProgress(reason, updatedReplicas string) {
+	if zs.IsClusterInUpgradingState() {
+		// Set the upgrade condition reason to be UpgradingZookeeperReason, message to be the upgradedReplicas
+		zs.SetUpgradingConditionTrue(reason, updatedReplicas)
+	}
+}
+
+func (zs *ZookeeperClusterStatus) GetLastCondition() (lastCondition *ClusterCondition) {
+	if zs.IsClusterInUpgradingState() {
+		_, lastCondition := zs.GetClusterCondition(ClusterConditionUpgrading)
+		return lastCondition
+	}
+	// nothing to do if we are neither upgrading nor rolling back,
+	return nil
+}

--- a/pkg/apis/zookeeper/v1beta1/status.go
+++ b/pkg/apis/zookeeper/v1beta1/status.go
@@ -216,6 +216,6 @@ func (zs *ZookeeperClusterStatus) GetLastCondition() (lastCondition *ClusterCond
 		_, lastCondition := zs.GetClusterCondition(ClusterConditionUpgrading)
 		return lastCondition
 	}
-	// nothing to do if we are neither upgrading nor rolling back,
+	// nothing to do if we are not upgrading,
 	return nil
 }

--- a/pkg/apis/zookeeper/v1beta1/status_test.go
+++ b/pkg/apis/zookeeper/v1beta1/status_test.go
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package v1beta1_test
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pravega/zookeeper-operator/pkg/apis/zookeeper/v1beta1"
+)
+
+var _ = Describe("ZookeeperCluster Status", func() {
+
+	var z v1beta1.ZookeeperCluster
+
+	BeforeEach(func() {
+		z = v1beta1.ZookeeperCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		}
+	})
+
+	Context("manually set pods ready condition to be true", func() {
+		BeforeEach(func() {
+			condition := v1beta1.ClusterCondition{
+				Type:               v1beta1.ClusterConditionPodsReady,
+				Status:             corev1.ConditionTrue,
+				Reason:             "",
+				Message:            "",
+				LastUpdateTime:     "",
+				LastTransitionTime: "",
+			}
+			z.Status.Conditions = append(z.Status.Conditions, condition)
+		})
+
+		It("should contains pods ready condition and it is true status", func() {
+			_, condition := z.Status.GetClusterCondition(v1beta1.ClusterConditionPodsReady)
+			Ω(condition.Status).To(Equal(corev1.ConditionTrue))
+		})
+	})
+
+	Context("set conditions", func() {
+		Context("set pods ready condition to be true", func() {
+			BeforeEach(func() {
+				z.Status.SetPodsReadyConditionFalse()
+				z.Status.SetPodsReadyConditionTrue()
+			})
+			It("should have pods ready condition with true status", func() {
+				_, condition := z.Status.GetClusterCondition(v1beta1.ClusterConditionPodsReady)
+				Ω(condition.Status).To(Equal(corev1.ConditionTrue))
+			})
+		})
+
+		Context("set pod ready condition to be false", func() {
+			BeforeEach(func() {
+				z.Status.SetPodsReadyConditionTrue()
+				z.Status.SetPodsReadyConditionFalse()
+			})
+
+			It("should have ready condition with false status", func() {
+				_, condition := z.Status.GetClusterCondition(v1beta1.ClusterConditionPodsReady)
+				Ω(condition.Status).To(Equal(corev1.ConditionFalse))
+			})
+
+			It("should have updated timestamps", func() {
+				_, condition := z.Status.GetClusterCondition(v1beta1.ClusterConditionPodsReady)
+				// TODO: check the timestamps
+				Ω(condition.LastUpdateTime).NotTo(Equal(""))
+				Ω(condition.LastTransitionTime).NotTo(Equal(""))
+			})
+		})
+	})
+})

--- a/pkg/apis/zookeeper/v1beta1/status_test.go
+++ b/pkg/apis/zookeeper/v1beta1/status_test.go
@@ -137,7 +137,7 @@ var _ = Describe("ZookeeperCluster Status", func() {
 
 			It("should have updated timestamps", func() {
 				_, condition := z.Status.GetClusterCondition(v1beta1.ClusterConditionPodsReady)
-				// TODO: check the timestamps
+				//check the timestamps
 				Ω(condition.LastUpdateTime).NotTo(Equal(""))
 				Ω(condition.LastTransitionTime).NotTo(Equal(""))
 			})
@@ -185,7 +185,7 @@ var _ = Describe("ZookeeperCluster Status", func() {
 
 			It("should have updated timestamps", func() {
 				_, condition := z.Status.GetClusterCondition(v1beta1.ClusterConditionUpgrading)
-				// TODO: check the timestamps
+				//check the timestamps
 				Ω(condition.LastUpdateTime).NotTo(Equal(""))
 				Ω(condition.LastTransitionTime).NotTo(Equal(""))
 			})
@@ -225,7 +225,7 @@ var _ = Describe("ZookeeperCluster Status", func() {
 
 			It("should have updated timestamps", func() {
 				_, condition := z.Status.GetClusterCondition(v1beta1.ClusterConditionError)
-				// TODO: check the timestamps
+				//check the timestamps
 				Ω(condition.LastUpdateTime).NotTo(Equal(""))
 				Ω(condition.LastTransitionTime).NotTo(Equal(""))
 			})

--- a/pkg/apis/zookeeper/v1beta1/status_test.go
+++ b/pkg/apis/zookeeper/v1beta1/status_test.go
@@ -50,7 +50,44 @@ var _ = Describe("ZookeeperCluster Status", func() {
 		})
 	})
 
-	Context("set conditions", func() {
+	Context("manually set pods upgrade condition to be true", func() {
+		BeforeEach(func() {
+			condition := v1beta1.ClusterCondition{
+				Type:               v1beta1.ClusterConditionUpgrading,
+				Status:             corev1.ConditionTrue,
+				Reason:             "",
+				Message:            "",
+				LastUpdateTime:     "",
+				LastTransitionTime: "",
+			}
+			z.Status.Conditions = append(z.Status.Conditions, condition)
+		})
+
+		It("should contains pods upgrade condition and it is true status", func() {
+			_, condition := z.Status.GetClusterCondition(v1beta1.ClusterConditionUpgrading)
+			Ω(condition.Status).To(Equal(corev1.ConditionTrue))
+		})
+	})
+	Context("manually set pods Error condition to be true", func() {
+		BeforeEach(func() {
+			condition := v1beta1.ClusterCondition{
+				Type:               v1beta1.ClusterConditionError,
+				Status:             corev1.ConditionTrue,
+				Reason:             "",
+				Message:            "",
+				LastUpdateTime:     "",
+				LastTransitionTime: "",
+			}
+			z.Status.Conditions = append(z.Status.Conditions, condition)
+		})
+
+		It("should contains pods upgrade condition and it is true status", func() {
+			_, condition := z.Status.GetClusterCondition(v1beta1.ClusterConditionError)
+			Ω(condition.Status).To(Equal(corev1.ConditionTrue))
+		})
+	})
+
+	Context("set conditions for pods ready", func() {
 		Context("set pods ready condition to be true", func() {
 			BeforeEach(func() {
 				z.Status.SetPodsReadyConditionFalse()
@@ -81,4 +118,69 @@ var _ = Describe("ZookeeperCluster Status", func() {
 			})
 		})
 	})
+
+	Context("set conditions for upgrade", func() {
+		Context("set pods upgrade condition to be true", func() {
+			BeforeEach(func() {
+				z.Status.SetUpgradingConditionFalse()
+				z.Status.SetUpgradingConditionTrue(" ", " ")
+			})
+			It("should have pods upgrade condition with true status", func() {
+				_, condition := z.Status.GetClusterCondition(v1beta1.ClusterConditionUpgrading)
+				Ω(condition.Status).To(Equal(corev1.ConditionTrue))
+			})
+		})
+
+		Context("set pod upgrade condition to be false", func() {
+			BeforeEach(func() {
+				z.Status.SetUpgradingConditionTrue(" ", " ")
+				z.Status.SetUpgradingConditionFalse()
+			})
+
+			It("should have upgrade condition with false status", func() {
+				_, condition := z.Status.GetClusterCondition(v1beta1.ClusterConditionUpgrading)
+				Ω(condition.Status).To(Equal(corev1.ConditionFalse))
+			})
+
+			It("should have updated timestamps", func() {
+				_, condition := z.Status.GetClusterCondition(v1beta1.ClusterConditionUpgrading)
+				// TODO: check the timestamps
+				Ω(condition.LastUpdateTime).NotTo(Equal(""))
+				Ω(condition.LastTransitionTime).NotTo(Equal(""))
+			})
+		})
+	})
+
+	Context("set conditions for Error", func() {
+		Context("set pods Error condition to be true", func() {
+			BeforeEach(func() {
+				z.Status.SetErrorConditionFalse()
+				z.Status.SetErrorConditionTrue(" ", " ")
+			})
+			It("should have pods Error condition with true status", func() {
+				_, condition := z.Status.GetClusterCondition(v1beta1.ClusterConditionError)
+				Ω(condition.Status).To(Equal(corev1.ConditionTrue))
+			})
+		})
+
+		Context("set pod Error condition to be false", func() {
+			BeforeEach(func() {
+				z.Status.SetErrorConditionTrue(" ", " ")
+				z.Status.SetErrorConditionFalse()
+			})
+
+			It("should have Error condition with false status", func() {
+				_, condition := z.Status.GetClusterCondition(v1beta1.ClusterConditionError)
+				Ω(condition.Status).To(Equal(corev1.ConditionFalse))
+			})
+
+			It("should have updated timestamps", func() {
+				_, condition := z.Status.GetClusterCondition(v1beta1.ClusterConditionError)
+				// TODO: check the timestamps
+				Ω(condition.LastUpdateTime).NotTo(Equal(""))
+				Ω(condition.LastTransitionTime).NotTo(Equal(""))
+			})
+		})
+	})
+
 })

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -25,7 +25,7 @@ const (
 
 	// DefaultZkContainerVersion is the default tag used for for the zookeeper
 	// container
-	DefaultZkContainerVersion = "latest"
+	DefaultZkContainerVersion = "0.2.7"
 
 	// DefaultZkContainerPolicy is the default container pull policy used
 	DefaultZkContainerPolicy = "Always"

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -12,14 +12,11 @@ package v1beta1
 
 import (
 	"fmt"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-type ClusterConditionType string
 
 const (
 	// DefaultZkContainerRepository is the default docker repo for the zookeeper
@@ -37,14 +34,6 @@ const (
 	// container is stopped. This gives clients time to disconnect from a
 	// specific node gracefully.
 	DefaultTerminationGracePeriod = 30
-
-	ClusterConditionPodsReady ClusterConditionType = "PodsReady"
-	ClusterConditionUpgrading                      = "Upgrading"
-	ClusterConditionError                          = "Error"
-
-	// Reasons for cluster upgrading condition
-	UpdatingZookeeperReason = "Updating Zookeeper"
-	UpgradeErrorReason      = "Upgrade Error"
 )
 
 // ZookeeperClusterSpec defines the desired state of ZookeeperCluster
@@ -132,198 +121,6 @@ func (s *ZookeeperClusterSpec) withDefaults(z *ZookeeperCluster) (changed bool) 
 		changed = true
 	}
 	return changed
-}
-
-// ZookeeperClusterStatus defines the observed state of ZookeeperCluster
-type ZookeeperClusterStatus struct {
-	// Members is the zookeeper members in the cluster
-	Members MembersStatus `json:"members"`
-
-	// Replicas is the number of number of desired replicas in the cluster
-	Replicas int32 `json:"replicas"`
-
-	// ReadyReplicas is the number of number of ready replicas in the cluster
-	ReadyReplicas int32 `json:"readyReplicas"`
-
-	// InternalClientEndpoint is the internal client IP and port
-	InternalClientEndpoint string `json:"internalClientEndpoint"`
-
-	// ExternalClientEndpoint is the internal client IP and port
-	ExternalClientEndpoint string `json:"externalClientEndpoint"`
-
-	MetaRootCreated bool `json:"metaRootCreated"`
-
-	// CurrentVersion is the current cluster version
-	CurrentVersion string `json:"currentVersion"`
-
-	TargetVersion string `json:"targetVersion"`
-
-	// Conditions list all the applied conditions
-	Conditions []ClusterCondition `json:"conditions,omitempty"`
-}
-
-// ClusterCondition shows the current condition of a Zookeeper cluster.
-// Comply with k8s API conventions
-type ClusterCondition struct {
-	// Type of Zookeeper cluster condition.
-	Type ClusterConditionType `json:"type"`
-
-	// Status of the condition, one of True, False, Unknown.
-	Status v1.ConditionStatus `json:"status"`
-
-	// The reason for the condition's last transition.
-	Reason string `json:"reason,omitempty"`
-
-	// A human readable message indicating details about the transition.
-	Message string `json:"message,omitempty"`
-
-	// The last time this condition was updated.
-	LastUpdateTime string `json:"lastUpdateTime,omitempty"`
-
-	// Last time the condition transitioned from one status to another.
-	LastTransitionTime string `json:"lastTransitionTime,omitempty"`
-}
-
-func (ps *ZookeeperClusterStatus) Init() {
-	// Initialise conditions
-	conditionTypes := []ClusterConditionType{
-		ClusterConditionPodsReady,
-		ClusterConditionUpgrading,
-		ClusterConditionError,
-	}
-	for _, conditionType := range conditionTypes {
-		if _, condition := ps.GetClusterCondition(conditionType); condition == nil {
-			c := newClusterCondition(conditionType, v1.ConditionFalse, "", "")
-			ps.setClusterCondition(*c)
-		}
-	}
-}
-
-func newClusterCondition(condType ClusterConditionType, status v1.ConditionStatus, reason, message string) *ClusterCondition {
-	return &ClusterCondition{
-		Type:               condType,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		LastUpdateTime:     "",
-		LastTransitionTime: "",
-	}
-}
-
-func (ps *ZookeeperClusterStatus) SetPodsReadyConditionTrue() {
-	c := newClusterCondition(ClusterConditionPodsReady, v1.ConditionTrue, "", "")
-	ps.setClusterCondition(*c)
-}
-
-func (ps *ZookeeperClusterStatus) SetPodsReadyConditionFalse() {
-	c := newClusterCondition(ClusterConditionPodsReady, v1.ConditionFalse, "", "")
-	ps.setClusterCondition(*c)
-}
-
-func (ps *ZookeeperClusterStatus) SetUpgradingConditionTrue(reason, message string) {
-	c := newClusterCondition(ClusterConditionUpgrading, v1.ConditionTrue, reason, message)
-	ps.setClusterCondition(*c)
-}
-
-func (ps *ZookeeperClusterStatus) SetUpgradingConditionFalse() {
-	c := newClusterCondition(ClusterConditionUpgrading, v1.ConditionFalse, "", "")
-	ps.setClusterCondition(*c)
-}
-
-func (ps *ZookeeperClusterStatus) SetErrorConditionTrue(reason, message string) {
-	c := newClusterCondition(ClusterConditionError, v1.ConditionTrue, reason, message)
-	ps.setClusterCondition(*c)
-}
-
-func (ps *ZookeeperClusterStatus) SetErrorConditionFalse() {
-	c := newClusterCondition(ClusterConditionError, v1.ConditionFalse, "", "")
-	ps.setClusterCondition(*c)
-}
-
-func (ps *ZookeeperClusterStatus) GetClusterCondition(t ClusterConditionType) (int, *ClusterCondition) {
-	for i, c := range ps.Conditions {
-		if t == c.Type {
-			return i, &c
-		}
-	}
-	return -1, nil
-}
-
-func (ps *ZookeeperClusterStatus) setClusterCondition(newCondition ClusterCondition) {
-	now := time.Now().Format(time.RFC3339)
-	position, existingCondition := ps.GetClusterCondition(newCondition.Type)
-
-	if existingCondition == nil {
-		ps.Conditions = append(ps.Conditions, newCondition)
-		return
-	}
-
-	if existingCondition.Status != newCondition.Status {
-		existingCondition.Status = newCondition.Status
-		existingCondition.LastTransitionTime = now
-		existingCondition.LastUpdateTime = now
-	}
-
-	if existingCondition.Reason != newCondition.Reason || existingCondition.Message != newCondition.Message {
-		existingCondition.Reason = newCondition.Reason
-		existingCondition.Message = newCondition.Message
-		existingCondition.LastUpdateTime = now
-	}
-
-	ps.Conditions[position] = *existingCondition
-}
-
-func (ps *ZookeeperClusterStatus) IsClusterInUpgradeFailedState() bool {
-	_, errorCondition := ps.GetClusterCondition(ClusterConditionError)
-	if errorCondition == nil {
-		return false
-	}
-	if errorCondition.Status == v1.ConditionTrue && errorCondition.Reason == "UpgradeFailed" {
-		return true
-	}
-	return false
-}
-
-func (ps *ZookeeperClusterStatus) IsClusterInUpgradingState() bool {
-	_, upgradeCondition := ps.GetClusterCondition(ClusterConditionUpgrading)
-	if upgradeCondition == nil {
-		return false
-	}
-	if upgradeCondition.Status == v1.ConditionTrue {
-		return true
-	}
-	return false
-}
-
-func (ps *ZookeeperClusterStatus) IsClusterInReadyState() bool {
-	_, readyCondition := ps.GetClusterCondition(ClusterConditionPodsReady)
-	if readyCondition != nil && readyCondition.Status == v1.ConditionTrue {
-		return true
-	}
-	return false
-}
-
-func (ps *ZookeeperClusterStatus) UpdateProgress(reason, updatedReplicas string) {
-	if ps.IsClusterInUpgradingState() {
-		// Set the upgrade condition reason to be UpgradingBookkeeperReason, message to be 0
-		ps.SetUpgradingConditionTrue(reason, updatedReplicas)
-	}
-}
-
-func (ps *ZookeeperClusterStatus) GetLastCondition() (lastCondition *ClusterCondition) {
-	if ps.IsClusterInUpgradingState() {
-		_, lastCondition := ps.GetClusterCondition(ClusterConditionUpgrading)
-		return lastCondition
-	}
-	// nothing to do if we are neither upgrading nor rolling back,
-	return nil
-}
-
-// MembersStatus is the status of the members of the cluster with both
-// ready and unready node membership lists
-type MembersStatus struct {
-	Ready   []string `json:"ready"`
-	Unready []string `json:"unready"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -12,11 +12,14 @@ package v1beta1
 
 import (
 	"fmt"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+type ClusterConditionType string
 
 const (
 	// DefaultZkContainerRepository is the default docker repo for the zookeeper
@@ -34,6 +37,14 @@ const (
 	// container is stopped. This gives clients time to disconnect from a
 	// specific node gracefully.
 	DefaultTerminationGracePeriod = 30
+
+	ClusterConditionPodsReady ClusterConditionType = "PodsReady"
+	ClusterConditionUpgrading                      = "Upgrading"
+	ClusterConditionError                          = "Error"
+
+	// Reasons for cluster upgrading condition
+	UpdatingZookeeperReason = "Updating Zookeeper"
+	UpgradeErrorReason      = "Upgrade Error"
 )
 
 // ZookeeperClusterSpec defines the desired state of ZookeeperCluster
@@ -141,6 +152,171 @@ type ZookeeperClusterStatus struct {
 	ExternalClientEndpoint string `json:"externalClientEndpoint"`
 
 	MetaRootCreated bool `json:"metaRootCreated"`
+
+	// CurrentVersion is the current cluster version
+	CurrentVersion string `json:"currentVersion"`
+
+	TargetVersion string `json:"targetVersion"`
+
+	// Conditions list all the applied conditions
+	Conditions []ClusterCondition `json:"conditions,omitempty"`
+}
+
+// ClusterCondition shows the current condition of a Zookeeper cluster.
+// Comply with k8s API conventions
+type ClusterCondition struct {
+	// Type of Zookeeper cluster condition.
+	Type ClusterConditionType `json:"type"`
+
+	// Status of the condition, one of True, False, Unknown.
+	Status v1.ConditionStatus `json:"status"`
+
+	// The reason for the condition's last transition.
+	Reason string `json:"reason,omitempty"`
+
+	// A human readable message indicating details about the transition.
+	Message string `json:"message,omitempty"`
+
+	// The last time this condition was updated.
+	LastUpdateTime string `json:"lastUpdateTime,omitempty"`
+
+	// Last time the condition transitioned from one status to another.
+	LastTransitionTime string `json:"lastTransitionTime,omitempty"`
+}
+
+func (ps *ZookeeperClusterStatus) Init() {
+	// Initialise conditions
+	conditionTypes := []ClusterConditionType{
+		ClusterConditionPodsReady,
+		ClusterConditionUpgrading,
+		ClusterConditionError,
+	}
+	for _, conditionType := range conditionTypes {
+		if _, condition := ps.GetClusterCondition(conditionType); condition == nil {
+			c := newClusterCondition(conditionType, v1.ConditionFalse, "", "")
+			ps.setClusterCondition(*c)
+		}
+	}
+}
+
+func newClusterCondition(condType ClusterConditionType, status v1.ConditionStatus, reason, message string) *ClusterCondition {
+	return &ClusterCondition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastUpdateTime:     "",
+		LastTransitionTime: "",
+	}
+}
+
+func (ps *ZookeeperClusterStatus) SetPodsReadyConditionTrue() {
+	c := newClusterCondition(ClusterConditionPodsReady, v1.ConditionTrue, "", "")
+	ps.setClusterCondition(*c)
+}
+
+func (ps *ZookeeperClusterStatus) SetPodsReadyConditionFalse() {
+	c := newClusterCondition(ClusterConditionPodsReady, v1.ConditionFalse, "", "")
+	ps.setClusterCondition(*c)
+}
+
+func (ps *ZookeeperClusterStatus) SetUpgradingConditionTrue(reason, message string) {
+	c := newClusterCondition(ClusterConditionUpgrading, v1.ConditionTrue, reason, message)
+	ps.setClusterCondition(*c)
+}
+
+func (ps *ZookeeperClusterStatus) SetUpgradingConditionFalse() {
+	c := newClusterCondition(ClusterConditionUpgrading, v1.ConditionFalse, "", "")
+	ps.setClusterCondition(*c)
+}
+
+func (ps *ZookeeperClusterStatus) SetErrorConditionTrue(reason, message string) {
+	c := newClusterCondition(ClusterConditionError, v1.ConditionTrue, reason, message)
+	ps.setClusterCondition(*c)
+}
+
+func (ps *ZookeeperClusterStatus) SetErrorConditionFalse() {
+	c := newClusterCondition(ClusterConditionError, v1.ConditionFalse, "", "")
+	ps.setClusterCondition(*c)
+}
+
+func (ps *ZookeeperClusterStatus) GetClusterCondition(t ClusterConditionType) (int, *ClusterCondition) {
+	for i, c := range ps.Conditions {
+		if t == c.Type {
+			return i, &c
+		}
+	}
+	return -1, nil
+}
+
+func (ps *ZookeeperClusterStatus) setClusterCondition(newCondition ClusterCondition) {
+	now := time.Now().Format(time.RFC3339)
+	position, existingCondition := ps.GetClusterCondition(newCondition.Type)
+
+	if existingCondition == nil {
+		ps.Conditions = append(ps.Conditions, newCondition)
+		return
+	}
+
+	if existingCondition.Status != newCondition.Status {
+		existingCondition.Status = newCondition.Status
+		existingCondition.LastTransitionTime = now
+		existingCondition.LastUpdateTime = now
+	}
+
+	if existingCondition.Reason != newCondition.Reason || existingCondition.Message != newCondition.Message {
+		existingCondition.Reason = newCondition.Reason
+		existingCondition.Message = newCondition.Message
+		existingCondition.LastUpdateTime = now
+	}
+
+	ps.Conditions[position] = *existingCondition
+}
+
+func (ps *ZookeeperClusterStatus) IsClusterInUpgradeFailedState() bool {
+	_, errorCondition := ps.GetClusterCondition(ClusterConditionError)
+	if errorCondition == nil {
+		return false
+	}
+	if errorCondition.Status == v1.ConditionTrue && errorCondition.Reason == "UpgradeFailed" {
+		return true
+	}
+	return false
+}
+
+func (ps *ZookeeperClusterStatus) IsClusterInUpgradingState() bool {
+	_, upgradeCondition := ps.GetClusterCondition(ClusterConditionUpgrading)
+	if upgradeCondition == nil {
+		return false
+	}
+	if upgradeCondition.Status == v1.ConditionTrue {
+		return true
+	}
+	return false
+}
+
+func (ps *ZookeeperClusterStatus) IsClusterInReadyState() bool {
+	_, readyCondition := ps.GetClusterCondition(ClusterConditionPodsReady)
+	if readyCondition != nil && readyCondition.Status == v1.ConditionTrue {
+		return true
+	}
+	return false
+}
+
+func (ps *ZookeeperClusterStatus) UpdateProgress(reason, updatedReplicas string) {
+	if ps.IsClusterInUpgradingState() {
+		// Set the upgrade condition reason to be UpgradingBookkeeperReason, message to be 0
+		ps.SetUpgradingConditionTrue(reason, updatedReplicas)
+	}
+}
+
+func (ps *ZookeeperClusterStatus) GetLastCondition() (lastCondition *ClusterCondition) {
+	if ps.IsClusterInUpgradingState() {
+		_, lastCondition := ps.GetClusterCondition(ClusterConditionUpgrading)
+		return lastCondition
+	}
+	// nothing to do if we are neither upgrading nor rolling back,
+	return nil
 }
 
 // MembersStatus is the status of the members of the cluster with both

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -38,7 +38,7 @@ const (
 
 // ZookeeperClusterSpec defines the desired state of ZookeeperCluster
 type ZookeeperClusterSpec struct {
-	// Image is the  container image. default is zookeeper:latest
+	// Image is the  container image. default is zookeeper:0.2.7
 	Image ContainerImage `json:"image,omitempty"`
 
 	// Labels specifies the labels to attach to pods the operator creates for

--- a/pkg/controller/zookeepercluster/zookeepercluster_controller.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller.go
@@ -140,6 +140,7 @@ func (r *ReconcileZookeeperCluster) Reconcile(request reconcile.Request) (reconc
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+	instance.Status.init()
 	changed := instance.WithDefaults()
 	if changed {
 		r.log.Info("Setting default settings for zookeeper-cluster")
@@ -298,7 +299,7 @@ func checkSyncTimeout(p *zookeeperv1beta1.ZookeeperCluster, reason string, updat
 		// then check if it reaches the timeout.
 		logs.Printf("jasmeet singh value of lastcondition.message = %s", lastCondition.Message)
 		parsedTime, _ := time.Parse(time.RFC3339, lastCondition.LastUpdateTime)
-		if time.Now().After(parsedTime.Add(time.Duration(3 * time.Minute))) {
+		if time.Now().After(parsedTime.Add(time.Duration(10 * time.Minute))) {
 			// timeout
 			return fmt.Errorf("progress deadline exceeded")
 		}

--- a/pkg/controller/zookeepercluster/zookeepercluster_controller.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller.go
@@ -139,7 +139,6 @@ func (r *ReconcileZookeeperCluster) Reconcile(request reconcile.Request) (reconc
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
-	instance.Status.Init()
 	changed := instance.WithDefaults()
 	if changed {
 		r.log.Info("Setting default settings for zookeeper-cluster")
@@ -449,6 +448,7 @@ func (r *ReconcileZookeeperCluster) reconcileClusterStatus(instance *zookeeperv1
 	if instance.Status.IsClusterInUpgradingState() || instance.Status.IsClusterInUpgradeFailedState() {
 		return nil
 	}
+	instance.Status.Init()
 	foundPods := &corev1.PodList{}
 	labelSelector := labels.SelectorFromSet(map[string]string{"app": instance.GetName()})
 	listOps := &client.ListOptions{

--- a/pkg/controller/zookeepercluster/zookeepercluster_controller.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller.go
@@ -246,7 +246,7 @@ func (r *ReconcileZookeeperCluster) upgradeStatefulSet(instance *zookeeperv1beta
 		return nil
 	}
 
-	//Setting the upgrade condition to true when the zk cluster is upgrading
+	//Setting the upgrade condition to true to trigger the upgrade
 	//When the zk cluster is upgrading Statefulset CurrentRevision and UpdateRevision are not equal and zk cluster image tag is not equal to CurrentVersion
 	if upgradeCondition.Status == corev1.ConditionFalse {
 		if instance.Status.IsClusterInReadyState() && foundSts.Status.CurrentRevision != foundSts.Status.UpdateRevision && instance.Spec.Image.Tag != instance.Status.CurrentVersion {

--- a/pkg/controller/zookeepercluster/zookeepercluster_controller_test.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller_test.go
@@ -259,8 +259,9 @@ var _ = Describe("ZookeeperCluster Controller", func() {
 				z.WithDefaults()
 				z.Status.Init()
 				next := z.DeepCopy()
-				next.Spec.Image.Tag = "0.2.5"
+				next.Spec.Image.Tag = "0.2.7"
 				next.Status.CurrentVersion = "0.2.6"
+				next.Status.SetPodsReadyConditionTrue()
 				st := zk.MakeStatefulSet(z)
 				cl = fake.NewFakeClient([]runtime.Object{next, st}...)
 				st = &appsv1.StatefulSet{}
@@ -288,7 +289,7 @@ var _ = Describe("ZookeeperCluster Controller", func() {
 				foundZookeeper := &v1beta1.ZookeeperCluster{}
 				_ = cl.Get(context.TODO(), req.NamespacedName, foundZookeeper)
 				Ω(err).To(BeNil())
-				Ω(foundZookeeper.Status.TargetVersion).To(BeEquivalentTo("0.2.5"))
+				Ω(foundZookeeper.Status.TargetVersion).To(BeEquivalentTo("0.2.7"))
 			})
 
 			It("should set the target version", func() {
@@ -296,7 +297,7 @@ var _ = Describe("ZookeeperCluster Controller", func() {
 				_ = cl.Get(context.TODO(), req.NamespacedName, foundZookeeper)
 
 				Ω(err).To(BeNil())
-				Ω(foundZookeeper.Status.TargetVersion).To(BeEquivalentTo("0.2.5"))
+				Ω(foundZookeeper.Status.TargetVersion).To(BeEquivalentTo("0.2.7"))
 			})
 		})
 
@@ -310,9 +311,9 @@ var _ = Describe("ZookeeperCluster Controller", func() {
 				z.WithDefaults()
 				z.Status.Init()
 				next := z.DeepCopy()
-				next.Spec.Image.Tag = "0.2.5"
+				next.Spec.Image.Tag = "0.2.7"
 				next.Status.CurrentVersion = "0.2.6"
-				next.Status.TargetVersion = "0.2.5"
+				next.Status.TargetVersion = "0.2.7"
 				next.Status.SetUpgradingConditionTrue(" ", " ")
 				st := zk.MakeStatefulSet(z)
 				cl = fake.NewFakeClient([]runtime.Object{next, st}...)
@@ -338,7 +339,7 @@ var _ = Describe("ZookeeperCluster Controller", func() {
 				foundZookeeper := &v1beta1.ZookeeperCluster{}
 				_ = cl.Get(context.TODO(), req.NamespacedName, foundZookeeper)
 				Ω(err).To(BeNil())
-				Ω(foundZookeeper.Status.CurrentVersion).To(BeEquivalentTo("0.2.5"))
+				Ω(foundZookeeper.Status.CurrentVersion).To(BeEquivalentTo("0.2.7"))
 			})
 
 			It("should set the target version to empty", func() {
@@ -360,7 +361,7 @@ var _ = Describe("ZookeeperCluster Controller", func() {
 				z.Status.Init()
 				next := z.DeepCopy()
 				next.Status.SetUpgradingConditionTrue(" ", "1")
-				next.Status.TargetVersion = "0.2.5"
+				next.Status.TargetVersion = "0.2.7"
 				st := zk.MakeStatefulSet(z)
 				cl = fake.NewFakeClient([]runtime.Object{next, st}...)
 				st = &appsv1.StatefulSet{}
@@ -401,7 +402,7 @@ var _ = Describe("ZookeeperCluster Controller", func() {
 				z.WithDefaults()
 				z.Status.Init()
 				next := z.DeepCopy()
-				next.Spec.Image.Tag = "0.2.5"
+				next.Spec.Image.Tag = "0.2.7"
 				next.Status.CurrentVersion = "0.2.6"
 				next.Status.TargetVersion = ""
 				next.Status.IsClusterInUpgradingState()

--- a/pkg/controller/zookeepercluster/zookeepercluster_controller_test.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller_test.go
@@ -13,6 +13,7 @@ package zookeepercluster
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/pravega/zookeeper-operator/pkg/apis/zookeeper/v1beta1"
 	"github.com/pravega/zookeeper-operator/pkg/zk"
@@ -371,8 +372,11 @@ var _ = Describe("ZookeeperCluster Controller", func() {
 				cl.Status().Update(context.TODO(), st)
 				r = &ReconcileZookeeperCluster{client: cl, scheme: s, zkClient: mockZkClient}
 				res, err = r.Reconcile(req)
-				res, err = r.Reconcile(req)
-				err = checkSyncTimeout(next, " ", 1, 0)
+				//sleeping for 3 seconds
+				time.Sleep(3 * time.Second)
+				//checking if more than 2 secs have passed from the last update time
+				err = checkSyncTimeout(next, " ", 1, 2*time.Second)
+
 			})
 
 			It("checking update replicas", func() {

--- a/pkg/controller/zookeepercluster/zookeepercluster_controller_test.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller_test.go
@@ -266,7 +266,7 @@ var _ = Describe("ZookeeperCluster Controller", func() {
 				cl = fake.NewFakeClient([]runtime.Object{next, st}...)
 				st = &appsv1.StatefulSet{}
 				err = cl.Get(context.TODO(), req.NamespacedName, st)
-				//changing the REvision vlue to simulate the update scenario
+				//changing the Revision value to simulate the upgrade scenario
 				st.Status.CurrentRevision = "CurrentRevision"
 				st.Status.UpdateRevision = "UpdateRevision"
 				cl.Status().Update(context.TODO(), st)
@@ -292,14 +292,7 @@ var _ = Describe("ZookeeperCluster Controller", func() {
 				logs.Printf("krishna value of tag = %s", fmt.Sprint(foundPravega.Status))
 				Ω(err).To(BeNil())
 				Ω(foundPravega.Status.TargetVersion).To(BeEquivalentTo("0.2.5"))
-
 			})
-
-			/*	It("should update the sts", func() {
-				foundSts := &appsv1.StatefulSet{}
-				err = cl.Get(context.TODO(), req.NamespacedName, foundSts)
-
-			})*/
 		})
 
 		Context("With an update to the client svc", func() {


### PR DESCRIPTION
Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>
### Change log description
This PR introduces the cluster condition to the zookeeper cluster status which appropriately shows the State of a Zookeeper cluster in case of Pods Ready, Upgrade and Error state

### Purpose of the change
To display the zookeeper cluster condition as part of the status field of the zookeeper cluster, which will fix #169 

### What the code does
1) It sets the cluster condition to Pods Ready, Upgrade, Error state
2) When all the pods of the zk sts are in ready state, in that case, it sets the pods ready condition to true
3) When the cluster is upgrading from one version to the other in that case it sets the upgrade condition to true
4) when the cluster is in upgrade failed state it sets the Error condition to true
5) Additionally, It sets the value of the current version in case of the fresh deployment of the zookeeper cluster it also sets the current version when the image tag of the zookeeper cluster is updated and the update is completed

### How to verify it
1) Deploy a Zookeeper cluster and after all the replicas have been deployed the  CurrentVersion 
    field  in the status of the zookeeper cluster will show the current image tag deployed by the 
    zookeeper operator, as well as the Pods Ready Condition, will be True as well.  
2) Upgrade the image tag in the zookeeper cluster, While the upgrade is in progress upgrade 
     condition will be true and when all the pods have been  upgraded then the upgrade condition 
     will become false and the Pods Ready Condition will be True and CurrentVersion field will display 
     the new image tag for the zookeeper cluster.
3) In case the Upgrade Fails in that case Error condition will be True.