### PR TITLE
Issue 177: Unable to configure storage resources of zookeeper PVCs

### DIFF
--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -34,6 +34,10 @@ const (
 	// container is stopped. This gives clients time to disconnect from a
 	// specific node gracefully.
 	DefaultTerminationGracePeriod = 30
+
+	// DefaultZookeeperCacheVolumeSize is the default volume size for the
+	// Zookeeper cache volume
+	DefaultZookeeperCacheVolumeSize = "20Gi"
 )
 
 // ZookeeperClusterSpec defines the desired state of ZookeeperCluster
@@ -376,9 +380,10 @@ func (p *Persistence) withDefaults() (changed bool) {
 		v1.ReadWriteOnce,
 	}
 
-	if len(p.PersistentVolumeClaimSpec.Resources.Requests) == 0 {
+	storage, _ := p.PersistentVolumeClaimSpec.Resources.Requests["storage"]
+	if storage.IsZero() {
 		p.PersistentVolumeClaimSpec.Resources.Requests = v1.ResourceList{
-			v1.ResourceStorage: resource.MustParse("20Gi"),
+			v1.ResourceStorage: resource.MustParse(DefaultZookeeperCacheVolumeSize),
 		}
 		changed = true
 	}


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>
### Change log description
We were not checking whether the persistence volume claim spec has a storage field, before setting the defaults. Due to that configured value was not taking effect

### Purpose of the change
Fixes #177 

### What the code does
Added a check to ensure `storage` field value is empty before setting  deaults 

### How to verify it
Verified by giving different values for storage in manifest file, and pvc are getting created accordingly. If storage is not specified pvcs are created with default size.
