### PR TITLE
Issue 91: PrestopHook configured for zookeeper cluster always fails

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,4 +20,4 @@ RUN chmod +x /usr/local/bin/*
 COPY --from=0 /zu/build/libs/zu.jar /root/
 
 RUN apt-get -q update && \
-    apt-get install -y dnsutils curl
+    apt-get install -y dnsutils curl procps

--- a/docker/bin/zookeeperTeardown.sh
+++ b/docker/bin/zookeeperTeardown.sh
@@ -39,6 +39,9 @@ for (( i = 0; i < 36; i++ )); do
   if [[ "$CONN_COUNT" -gt 0 ]]; then
     echo "$CONN_COUNT non-local connections still connected."
     sleep 5
+  else
+    echo "$CONN_COUNT non-local connections"
+    break
   fi
 done
 

--- a/docker/bin/zookeeperTeardown.sh
+++ b/docker/bin/zookeeperTeardown.sh
@@ -36,10 +36,11 @@ fi
 # "terminationGracePeriodSeconds" before focibly killing the container
 CONN_COUNT=`echo cons | nc localhost 2181 | grep -v "^$" |grep -v "/127.0.0.1:" | wc -l`
 for (( i = 0; i < 36; i++ )); do
-  echo "$CONN_COUNT non-local connections still connected."
-  sleep 5
-  CONN_COUNT=`echo cons | nc localhost 2181 | grep -v "^$" |grep -v "/127.0.0.1:" | wc -l`
+  if [[ "$CONN_COUNT" -gt 0 ]]; then
+    echo "$CONN_COUNT non-local connections still connected."
+    sleep 5
+  fi
 done
 
 # Kill the primary process ourselves to circumvent the terminationGracePeriodSeconds
-ps -ef | grep zoo.cfg | grep -v grep | awk '{print $1}' | xargs kill
+ps -ef | grep zoo.cfg | grep -v grep | awk '{print $2}' | xargs kill

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -33,7 +33,7 @@ const (
 	// DefaultTerminationGracePeriod is the default time given before the
 	// container is stopped. This gives clients time to disconnect from a
 	// specific node gracefully.
-	DefaultTerminationGracePeriod = 30
+	DefaultTerminationGracePeriod = 180
 
 	// DefaultZookeeperCacheVolumeSize is the default volume size for the
 	// Zookeeper cache volume
@@ -242,7 +242,7 @@ type PodPolicy struct {
 
 	// TerminationGracePeriodSeconds is the amount of time that kubernetes will
 	// give for a pod instance to shutdown normally.
-	// The default value is 1800.
+	// The default value is 180.
 	TerminationGracePeriodSeconds int64 `json:"terminationGracePeriodSeconds"`
 }
 


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>
### Change log description
Default Termination grace period was set to 30s, and in tearDown.sh we were waiting for 180s for client connection to terminate. Due to this after grace period is over, kubernetes is sending SIGKILL due to that we were getting `137` error code. (https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods)

### Purpose of the change
Fixes #91 

### What the code does
Increased default termination grace period to 180s. In teardown script, corrected the  loop for waiting for client connection. Also installed `ps` in container, as zookeeper-3.5.5 doesnt have it.
### How to verify it
Verified the following scenarios
1. Deleted pod
 2. Scale down the replicas
 3. Deleted zk  cluster. In all these scenarios, prestophook failure is not observed in kubectl events
