### PR TITLE
Issue 188: Migration to helm v3, making cluster specs overridable and adding self-validating hooks

### DIFF
--- a/charts/zookeeper-operator/Chart.yaml
+++ b/charts/zookeeper-operator/Chart.yaml
@@ -1,13 +1,10 @@
-apiVersion: v1
+apiVersion: v2
 name: zookeeper-operator
-version: 0.2.7
+version: 0.1.0
 appVersion: 0.2.7
-description: zookeeper operator Helm chart for Kubernetes
+description: Zookeeper Operator Helm chart for Kubernetes
 keywords:
 - zookeeper
 - storage
-home: https://github.com/pravega/zookeeper-operator/blob/master/charts/zookeeper-operator
+home: https://github.com/pravega/zookeeper-operator
 icon: https://zookeeper.apache.org/images/zookeeper_small.gif
-sources:
-- https://github.com/pravega/zookeeper-operator/blob/master/charts/zookeeper-operator
-engine: gotpl

--- a/charts/zookeeper-operator/Chart.yaml
+++ b/charts/zookeeper-operator/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v2
 name: zookeeper-operator
 version: 0.1.0
-appVersion: 0.2.7
 description: Zookeeper Operator Helm chart for Kubernetes
 keywords:
 - zookeeper

--- a/charts/zookeeper-operator/README.md
+++ b/charts/zookeeper-operator/README.md
@@ -1,0 +1,46 @@
+# Zookeeper Operator Helm Chart
+
+Installs [Zookeeper Operator](https://github.com/pravega/zookeeper-operator) to create/configure/manage Zookeeper clusters atop Kubernetes.
+
+## Introduction
+
+This chart bootstraps a [Zookeeper Operator](https://github.com/pravega/zookeeper-operator) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+  - Kubernetes 1.15+ with Beta APIs
+  - Helm 3+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```
+$ helm install my-release zookeeper-operator
+```
+
+The command deploys zookeeper-operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```
+$ helm uninstall my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Zookeeper operator chart and their default values.
+
+| Parameter | Description | Default |
+| ----- | ----------- | ------ |
+| `image.repository` | Image repository | `pravega/zookeeper-operator` |
+| `image.tag` | Image tag | `0.2.7` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `crd.create` | Create zookeeper CRD | `true` |
+| `rbac.create` | Create RBAC resources | `true` |
+| `serviceAccount.create` | Create service account | `true` |
+| `serviceAccount.name` | Name for the service account | `zookeeper-operator` |
+| `watchNamespace` | Namespaces to be watched  | `""` |

--- a/charts/zookeeper-operator/templates/crd.yaml
+++ b/charts/zookeeper-operator/templates/crd.yaml
@@ -21,6 +21,14 @@ spec:
     type: integer
     description: The number of ZooKeeper servers in the ensemble that are in a Ready state
     JSONPath: .status.readyReplicas
+  - name: Version
+    type: string
+    description: The current Zookeeper version
+    JSONPath: .status.currentVersion
+  - name: Desired Version
+    type: string
+    description: The desired Zookeeper version
+    JSONPath: .spec.image.tag
   - name: Internal Endpoint
     type: string
     description: Client endpoint internal to cluster network

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -20,7 +20,6 @@ serviceAccount:
 crd:
   create: true
 
-#
 # Specifies which namespace the Operator should watch for new ClusterResource resources
 # Default: "" == Watch ALL namespaces
 watchNamespace: ""

--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -1,13 +1,10 @@
-apiVersion: v1
+apiVersion: v2
 name: zookeeper
-version: 0.2.7
+description: Zookeeper Helm chart for Kubernetes
+version: 0.1.0
 appVersion: 0.2.7
-description: zookeeper Helm chart for Kubernetes
 keywords:
 - zookeeper
 - storage
-home: https://github.com/pravega/zookeeper-operator/blob/master/charts/zookeeper
+home: https://github.com/apache/zookeeper
 icon: https://zookeeper.apache.org/images/zookeeper_small.gif
-sources:
-- https://github.com/apache/zookeeper
-engine: gotpl

--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v2
 name: zookeeper
 description: Zookeeper Helm chart for Kubernetes
 version: 0.1.0
-appVersion: 0.2.7
 keywords:
 - zookeeper
 - storage

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -1,0 +1,63 @@
+# Zookeeper Helm Chart
+
+Installs Zookeeper clusters atop Kubernetes.
+
+## Introduction
+
+This chart creates a Zookeeper cluster in [Kubernetes](http://kubernetes.io) using the [Helm](https://helm.sh) package manager. The chart can be installed multiple times to create Zookeeper cluster in multiple namespaces.
+
+## Prerequisites
+
+  - Kubernetes 1.15+ with Beta APIs
+  - Helm 3+
+  - Zookeeper Operator. You can install it using its own [Helm chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/zookeeper-operator)
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```
+$ helm install my-release zookeeper
+```
+
+The command deploys zookeeper on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```
+$ helm uninstall my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Zookeeper chart and their default values.
+
+| Parameter | Description | Default |
+| ----- | ----------- | ------ |
+| `replicas` | Expected size of the zookeeper cluster (valid range is from 1 to 7) | `3` |
+| `image.repository` | Image repository | `pravega/zookeeper` |
+| `image.tag` | Image tag | `0.2.7` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `domainName` | Domain name to be used for DNS | |
+| `labels` | Specifies the labels to be attached | `{}` |
+| `ports` | Groups the ports for a zookeeper cluster node for easy access | `[]` |
+| `pod` | Defines the policy to create new pods for the zookeeper cluster | `{}` |
+| `pod.labels` | Labels to attach to the pods | `{}` |
+| `pod.nodeSelector` | | `{}` |
+| `pod.affinity` | Specifies scheduling constraints on pods | `{}` |
+| `pod.resources` | Specifies resource requirements for the container | `{}` |
+| `pod.tolerations` | Specifies the pod's tolerations | `[]` |
+| `pod.env` | List of environment variables to set in the container | `[]` |
+| `pod.annotations` | Specifies the annotations to attach to pods | `{}` |
+| `pod.securityContext` | Specifies the security context for the entire pod | |
+| `pod.terminationGracePeriodSeconds` | Amount of time given to the pod to shutdown normally | `180` |
+| `config.initLimit` | Amount of time (in ticks) to allow followers to connect and sync to a leader | `10` |
+| `config.tickTime` | Length of a single tick which is the basic time unit used by Zookeeper (measured in milliseconds) | `2000` |
+| `config.syncLimit` | Amount of time (in ticks) to allow followers to sync with Zookeeper | `2` |
+| `config.quorumListenOnAllIPs` | Whether Zookeeper server will listen for connections from its peers on all available IP addresses | `false` |
+| `persistence.reclaimPolicy` | Reclaim policy for persistent volumes | `Delete` |
+| `persistence.cacheVolumeRequest` | Storage requests for cache volume | `20Gi` |

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters of the Zookeeper chart and
 | `ports` | Groups the ports for a zookeeper cluster node for easy access | `[]` |
 | `pod` | Defines the policy to create new pods for the zookeeper cluster | `{}` |
 | `pod.labels` | Labels to attach to the pods | `{}` |
-| `pod.nodeSelector` | | `{}` |
+| `pod.nodeSelector` | Map of key-value pairs to be present as labels in the node in which the pod should run | `{}` |
 | `pod.affinity` | Specifies scheduling constraints on pods | `{}` |
 | `pod.resources` | Specifies resource requirements for the container | `{}` |
 | `pod.tolerations` | Specifies the pod's tolerations | `[]` |
@@ -60,4 +60,5 @@ The following table lists the configurable parameters of the Zookeeper chart and
 | `config.syncLimit` | Amount of time (in ticks) to allow followers to sync with Zookeeper | `2` |
 | `config.quorumListenOnAllIPs` | Whether Zookeeper server will listen for connections from its peers on all available IP addresses | `false` |
 | `persistence.reclaimPolicy` | Reclaim policy for persistent volumes | `Delete` |
-| `persistence.cacheVolumeRequest` | Storage requests for cache volume | `20Gi` |
+| `persistence.storageClassName` | Storage class for persistent volumes | `standard` |
+| `persistence.volumeSize` | Size of the volume requested for persistent volumes | `20Gi` |

--- a/charts/zookeeper/templates/_helpers.tpl
+++ b/charts/zookeeper/templates/_helpers.tpl
@@ -14,3 +14,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "hook.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-post-install-upgrade" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/zookeeper/templates/post-install-upgrade-hooks.yaml
+++ b/charts/zookeeper/templates/post-install-upgrade-hooks.yaml
@@ -1,0 +1,111 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "hook.fullname" . }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+rules:
+- apiGroups:
+  - zookeeper.pravega.io
+  resources:
+  - "*"
+  verbs:
+  - get
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "hook.fullname" . }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+subjects:
+- kind: ServiceAccount
+  name: {{ template "hook.fullname" . }}
+  namespace: {{.Release.Namespace}}
+roleRef:
+  kind: Role
+  name: {{ template "hook.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "hook.fullname" . }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "hook.fullname" . }}
+  annotations:
+      "helm.sh/hook": post-install, post-upgrade
+      "helm.sh/hook-weight": "1"
+      "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+data:
+  validations.sh: |
+    #!/bin/sh
+    set -e
+
+    sleep 30
+
+    replicas=`kubectl get zk -n {{ .Release.Namespace }} {{ template "zookeeper.fullname" . }} -o jsonpath='{.status.replicas}'`
+    readyReplicas=`kubectl get zk -n {{ .Release.Namespace }} {{ template "zookeeper.fullname" . }} -o jsonpath='{.status.readyReplicas}'`
+    currentVersion=`kubectl get zk -n {{ .Release.Namespace }} {{ template "zookeeper.fullname" . }} -o jsonpath='{.status.currentVersion}'`
+    targetVersion=`kubectl get zk -n {{ .Release.Namespace }} {{ template "zookeeper.fullname" . }} -o jsonpath='{.spec.image.tag}'`
+
+    echo "ZookeeperCluster replicas: $currentReplicas"
+    echo "ZookeeperCluster readyReplicas: $readyReplicas"
+    echo "ZookeeperCluster currentVersion: $currentVersion"
+    echo "ZookeeperCluster targetVersion: $targetVersion"
+
+    if [ $readyReplicas != $replicas ]; then
+        exit 1
+    fi
+
+    if [ $currentVersion != $targetVersion ]; then
+        exit 2
+    fi
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "hook.fullname" . }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: {{ template "hook.fullname" . }}
+    spec:
+      serviceAccountName: {{ template "hook.fullname" . }}
+      restartPolicy: Never
+      containers:
+      - name: post-install-upgrade-job
+        image: "{{ .Values.hooks.image.repository }}:{{ .Values.hooks.image.tag }}"
+        command:
+          - /scripts/validations.sh
+        volumeMounts:
+          - name: sh
+            mountPath: /scripts
+            readOnly: true
+      volumes:
+        - name: sh
+          configMap:
+            name: {{ template "hook.fullname" . }}
+            defaultMode: 0555

--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -9,10 +9,40 @@ spec:
     repository: {{ .Values.image.repository }}
     tag: {{ .Values.image.tag }}
     pullPolicy: {{ .Values.image.pullPolicy }}
+  domainName: {{ .Values.domainName }}
+  labels:
+{{ toYaml .Values.labels | indent 4 }}
+  ports:
+{{ toYaml .Values.ports | indent 4 }}
+  {{- if .Values.pod }}
+  pod:
+    labels:
+{{ toYaml .Values.pod.labels | indent 6 }}
+    nodeSelector:
+{{ toYaml .Values.pod.nodeSelector | indent 6 }}
+    affinity:
+{{ toYaml .Values.pod.affinity | indent 6 }}
+    resources:
+{{ toYaml .Values.pod.resources | indent 6 }}
+    tolerations:
+{{ toYaml .Values.pod.tolerations | indent 6 }}
+    env:
+{{ toYaml .Values.pod.env | indent 6 }}
+    annotations:
+{{ toYaml .Values.pod.annotations | indent 6 }}
+    securityContext:
+{{ toYaml .Values.pod.securityContext | indent 6 }}
+    terminationGracePeriodSeconds: {{ .Values.pod.terminationGracePeriodSeconds }}
+  {{- end }}
+  {{- if .Values.config }}
+  config:
+    initLimit: {{ .Values.config.initLimit }}
+    tickTime: {{ .Values.config.tickTime }}
+    syncLimit: {{ .Values.config.syncLimit }}
+    quorumListenOnAllIPs: {{ .Values.config.quorumListenOnAllIPs }}
+  {{- end }}
   persistence:
-    accessModes: [ "ReadWriteOnce" ]
-    storageClassName: {{ .Values.storage.className }}
-    reclaimPolicy: {{ .Values.storage.reclaimPolicy }}
+    reclaimPolicy: {{ .Values.persistence.reclaimPolicy }}
     resources:
       requests:
-        storage: {{ .Values.storage.cacheVolumeRequest }}
+        storage: {{ .Values.persistence.cacheVolumeRequest }}

--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -43,6 +43,8 @@ spec:
   {{- end }}
   persistence:
     reclaimPolicy: {{ .Values.persistence.reclaimPolicy }}
-    resources:
-      requests:
-        storage: {{ .Values.persistence.cacheVolumeRequest }}
+    spec:
+      storageClassName: {{ .Values.persistence.storageClassName }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.volumeSize }}

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -9,16 +9,16 @@ domainName:
 labels: {}
 ports: []
 
-pod:
-  labels: {}
-  nodeSelector: {}
-  affinity: {}
-  resources: {}
-  tolerations: []
-  env: []
-  annotations: {}
-  securityContext:
-  terminationGracePeriodSeconds: 180
+pod: {}
+  # labels: {}
+  # nodeSelector: {}
+  # affinity: {}
+  # resources: {}
+  # tolerations: []
+  # env: []
+  # annotations: {}
+  # securityContext:
+  # terminationGracePeriodSeconds: 180
 
 config: {}
   # initLimit: 10

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -27,10 +27,11 @@ config: {}
   # quorumListenOnAllIPs: false
 
 persistence:
+  storageClassName: standard
   # specifying reclaim policy for PersistentVolumes
   # accepted values - Delete / Retain
   reclaimPolicy: Delete
-  cacheVolumeRequest: 20Gi
+  volumeSize: 20Gi
 
 hooks:
   image:

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -5,9 +5,34 @@ image:
   tag: 0.2.7
   pullPolicy: IfNotPresent
 
-storage:
-  className: standard
+domainName:
+labels: {}
+ports: []
+
+pod:
+  labels: {}
+  nodeSelector: {}
+  affinity: {}
+  resources: {}
+  tolerations: []
+  env: []
+  annotations: {}
+  securityContext:
+  terminationGracePeriodSeconds: 180
+
+config: {}
+  # initLimit: 10
+  # tickTime: 2000
+  # syncLimit: 2
+  # quorumListenOnAllIPs: false
+
+persistence:
   # specifying reclaim policy for PersistentVolumes
   # accepted values - Delete / Retain
   reclaimPolicy: Delete
-  cacheVolumeRequest: 10Gi
+  cacheVolumeRequest: 20Gi
+
+hooks:
+  image:
+    repository: lachlanevenson/k8s-kubectl
+    tag: v1.16.10

--- a/deploy/crds/zookeeper_v1beta1_zookeepercluster_cr.yaml
+++ b/deploy/crds/zookeeper_v1beta1_zookeepercluster_cr.yaml
@@ -2,9 +2,7 @@ apiVersion: zookeeper.pravega.io/v1beta1
 kind: ZookeeperCluster
 metadata:
   name: zookeeper
-  namespace: default
 spec:
-  # Add fields here
   replicas: 3
   image:
     repository: pravega/zookeeper

--- a/deploy/crds/zookeeper_v1beta1_zookeepercluster_cr.yaml
+++ b/deploy/crds/zookeeper_v1beta1_zookeepercluster_cr.yaml
@@ -10,9 +10,9 @@ spec:
     repository: pravega/zookeeper
     tag: 0.2.7
   persistence:
-    accessModes: [ "ReadWriteOnce" ]
-    storageClassName: "standard"
     reclaimPolicy: Delete
-    resources:
-      requests:
-        storage: 10Gi
+    spec:
+      storageClassName: "standard"
+      resources:
+        requests:
+          storage: 20Gi

--- a/deploy/crds/zookeeper_v1beta1_zookeepercluster_crd.yaml
+++ b/deploy/crds/zookeeper_v1beta1_zookeepercluster_crd.yaml
@@ -20,14 +20,14 @@ spec:
     type: integer
     description: The number of ZooKeeper servers in the ensemble that are in a Ready state
     JSONPath: .status.readyReplicas
-  - name: version
+  - name: Version
     type: string
     description: The current Zookeeper version
     JSONPath: .status.currentVersion
-  - name: Desired version
+  - name: Desired Version
     type: string
     description: The desired Zookeeper version
-    JSONPath: .spec.image.tag    
+    JSONPath: .spec.image.tag
   - name: Internal Endpoint
     type: string
     description: Client endpoint internal to cluster network

--- a/deploy/default_ns/rbac.yaml
+++ b/deploy/default_ns/rbac.yaml
@@ -47,7 +47,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: zookeeper-operator-role-binding
+  name: zookeeper-operator
 subjects:
 - kind: ServiceAccount
   name: zookeeper-operator


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Updates the charts and the the helm commands to work with helm v3. It makes all the cluster specs overridable through Helm values. Also adds self validating post-install and post-upgrade hooks to the charts.

### Purpose of the change
Fixes #188 

### What the code does
Makes all cluster specs overridable and adds self-validating post-install and post-upgrade hooks to the charts.

### How to verify it
User should be able to follow the instructions mentioned in the documentation to install/delete a zookeeper operator and zookeeper cluster using charts via helm v3. User should be able to modify any of the zookeeper cluster specs through the values.yaml file.