### PR TITLE
Issue 193: Fix envoy waiting block

### DIFF
--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -51,6 +51,7 @@ if [ -f $DYNCONFIG ]; then
   ONDISK_DYN_CONFIG=true
 fi
 
+set +e
 # Check if envoy is up and running
 if [[ -n "$ENVOY_SIDECAR_STATUS" ]]; then
   COUNT=0
@@ -66,6 +67,7 @@ if [[ -n "$ENVOY_SIDECAR_STATUS" ]]; then
     fi
   done
 fi
+set -e
 
 # Determine if there is a ensemble available to join by checking the service domain
 set +e


### PR DESCRIPTION
Signed-off-by: Daniel Gonçalves <daniel.dias.g@gmail.com>

The block code that detects and waits for the Envoy does not work because of the ```set -e line```.
The line ```SC=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:15000/ready)``` fails and the script stops running.

I fixed that by disable the flag in this block of code (simple fix).

Edit: format