### PR TITLE
Issue 183: Prefixing service ports with tcp to comply with istio standards ADDENDUM

### DIFF
--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -196,6 +196,7 @@ func MakeHeadlessService(z *v1beta1.ZookeeperCluster) *v1.Service {
 		{Name: "tcp-client", Port: ports.Client},
 		{Name: "tcp-quorum", Port: ports.Quorum},
 		{Name: "tcp-leader-election", Port: ports.Leader},
+		{Name: "tcp-metrics", Port: ports.Metrics},
 	}
 	return makeService(headlessSvcName(z), svcPorts, false, z)
 }

--- a/pkg/zk/generators_test.go
+++ b/pkg/zk/generators_test.go
@@ -177,6 +177,12 @@ var _ = Describe("Generators Spec", func() {
 			s = zk.MakeHeadlessService(z)
 		})
 
+		It("should have a client port", func() {
+			p, err := utils.ServicePortByName(s.Spec.Ports, "tcp-client")
+			Ω(err).To(BeNil())
+			Ω(p.Port).To(BeEquivalentTo(2181))
+		})
+
 		It("should have a quorum port", func() {
 			p, err := utils.ServicePortByName(s.Spec.Ports, "tcp-quorum")
 			Ω(err).To(BeNil())
@@ -187,6 +193,12 @@ var _ = Describe("Generators Spec", func() {
 			p, err := utils.ServicePortByName(s.Spec.Ports, "tcp-leader-election")
 			Ω(err).To(BeNil())
 			Ω(p.Port).To(BeEquivalentTo(3888))
+		})
+
+		It("should have a metrics port", func() {
+			p, err := utils.ServicePortByName(s.Spec.Ports, "tcp-metrics")
+			Ω(err).To(BeNil())
+			Ω(p.Port).To(BeEquivalentTo(7000))
 		})
 
 		It("should have a the client svc name", func() {


### PR DESCRIPTION
### Change log description

Re-add tcp-metrics to headless service
Fixed tests

### Purpose of the change

This is an addendum to #183 that broke the monitoring.


### How to verify it

Run unit-tests