### PR TITLE
Make kubernetes cluster domain configurable

### DIFF
--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -74,6 +74,9 @@ type ZookeeperClusterSpec struct {
 
 	// Domain Name to be used for DNS
 	DomainName string `json:"domainName,omitempty"`
+
+	// Domain of the kubernetes cluster, defaults to cluster.local
+	KubernetesClusterDomain string `json:"kubernetesClusterDomain,omitempty"`
 }
 
 func (s *ZookeeperClusterSpec) withDefaults(z *ZookeeperCluster) (changed bool) {
@@ -151,6 +154,14 @@ func (z *ZookeeperCluster) WithDefaults() bool {
 // ConfigMapName returns the name of the cluster config-map
 func (z *ZookeeperCluster) ConfigMapName() string {
 	return fmt.Sprintf("%s-configmap", z.GetName())
+}
+
+// GetKubernetesClusterDomain returns the cluster domain of kubernetes
+func (z *ZookeeperCluster) GetKubernetesClusterDomain() string {
+	if z.Spec.KubernetesClusterDomain == "" {
+		return "cluster.local"
+	}
+	return z.Spec.KubernetesClusterDomain
 }
 
 // ZookeeperPorts returns a struct of ports

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types_test.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types_test.go
@@ -109,6 +109,10 @@ var _ = Describe("ZookeeperCluster Types", func() {
 				Ω(z.ConfigMapName()).To(Equal("example-configmap"))
 			})
 
+			It("should give cluster.local as cluster domain", func() {
+				Ω(z.GetKubernetesClusterDomain()).To(Equal("cluster.local"))
+			})
+
 			It("should give clientservicename as example-client", func() {
 				Ω(z.GetClientServiceName()).To(Equal("example-client"))
 			})
@@ -123,6 +127,21 @@ var _ = Describe("ZookeeperCluster Types", func() {
 
 			It("should set SyncLimit to 2", func() {
 				Ω(c.SyncLimit).To(Equal(2))
+			})
+		})
+
+		Context("Overriden cluster domain", func() {
+
+			var z2 v1beta1.ZookeeperCluster
+
+			BeforeEach(func() {
+				z2 = *z.DeepCopy()
+				z2.Spec.KubernetesClusterDomain = "foo.bar"
+				z2.WithDefaults()
+			})
+
+			It("should give cluster.local as foo.bar", func() {
+				Ω(z2.GetKubernetesClusterDomain()).To(Equal("foo.bar"))
 			})
 		})
 

--- a/pkg/utils/zookeeper_util.go
+++ b/pkg/utils/zookeeper_util.go
@@ -25,7 +25,7 @@ const (
 
 func GetZkServiceUri(zoo *v1beta1.ZookeeperCluster) (zkUri string) {
 	zkClientPort, _ := ContainerPortByName(zoo.Spec.Ports, "client")
-	zkUri = zoo.GetClientServiceName() + "." + zoo.GetNamespace() + ".svc.cluster.local:" + strconv.Itoa(int(zkClientPort))
+	zkUri = zoo.GetClientServiceName() + "." + zoo.GetNamespace() + ".svc." + zoo.GetKubernetesClusterDomain() + ":" + strconv.Itoa(int(zkClientPort))
 	return zkUri
 }
 

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -31,7 +31,7 @@ const (
 )
 
 func headlessDomain(z *v1beta1.ZookeeperCluster) string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local", headlessSvcName(z), z.GetNamespace())
+	return fmt.Sprintf("%s.%s.svc.%s", headlessSvcName(z), z.GetNamespace(), z.GetKubernetesClusterDomain())
 }
 
 func headlessSvcName(z *v1beta1.ZookeeperCluster) string {

--- a/pkg/zk/generators_test.go
+++ b/pkg/zk/generators_test.go
@@ -117,6 +117,36 @@ var _ = Describe("Generators Spec", func() {
 
 			})
 		})
+		Context("with overridden kubernetes cluster domain", func() {
+			var cfg string
+
+			BeforeEach(func() {
+				z := &v1beta1.ZookeeperCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "example",
+						Namespace: "default",
+					},
+					Spec: v1beta1.ZookeeperClusterSpec{
+						KubernetesClusterDomain: "foo.bar",
+					},
+				}
+				z.WithDefaults()
+				cm = zk.MakeConfigMap(z)
+			})
+
+			Context("env.sh", func() {
+				BeforeEach(func() {
+					cfg = cm.Data["env.sh"]
+				})
+
+				It("should set the DOMAIN to the overridden headless domain", func() {
+					Ω(cfg).
+						To(ContainSubstring(
+							"DOMAIN=example-headless.default.svc.foo.bar\n"))
+				})
+
+			})
+		})
 	})
 
 	Context("#MakeClientService", func() {


### PR DESCRIPTION
### Change log description

Instead of hard-coding "cluster.local" as the kubernetes cluster domain, this makes that setting configurable.

Analogous to this change I made to the Banzai Kafka Operator: https://github.com/banzaicloud/kafka-operator/pull/361

### Purpose of the change

My cluster doesn't use `cluster.local` as our cluster domain, so DNS lookups were failing. Changing it to be configurable allows me to set it in the `ZookeeperCluster` object and successfully bring up a zookeeper cluster.

### What the code does

Adds a parameter to `ZookeeperCluster` called `kubernetesClusterDomain`, which, when set, is used everywhere in the code where `cluster.local` is currently used.

### How to verify it

Kind of tricky if your cluster already works, but you could create a `ZookeeperCluster` with `kubernetesClusterDomain` set to something other than `cluster.local` and watch the cluster fail to create.

I'm not familiar with the Ginkgo testing framework, so I'm not sure if the way I added a test meets its conventions, but it does test for the overridden value.