### PR TITLE
Operator can watch a configurable set of namespaces

### DIFF
--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -27,8 +27,9 @@ serviceAccount:
 crd:
   create: true
 
-## Specifies which namespace the Operator should watch over.
-## An empty string means all namespaces.
+## Specifies which namespace(s) the Operator should watch over.
+## Default: An empty string means all namespaces.
+## Multiple namespaces can be configured using a comma separated list of namespaces
 watchNamespace: ""
 
 ## Operator pod resources


### PR DESCRIPTION
### Change log description

This patch extends the watch mechanism in operator so the ZookeeperCluster resources can be deployed in different namespaces than where the operator runs.

### Purpose of the change

Fixes #142 


### How to verify it

_(Steps to verify that the changes are effective)_
