### PR TITLE
Issue 204: ZK-operator does not add version to the CR status during upgrade

### DIFF
--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -106,7 +106,9 @@ func (s *ZookeeperClusterSpec) withDefaults(z *ZookeeperCluster) (changed bool) 
 		}
 		changed = true
 	} else {
-		var foundClient, foundQuorum, foundLeader, foundMetrics bool
+		var (
+			foundClient, foundQuorum, foundLeader, foundMetrics bool
+		)
 		for i := 0; i < len(s.Ports); i++ {
 			if s.Ports[i].Name == "client" {
 				foundClient = true

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -105,7 +105,41 @@ func (s *ZookeeperClusterSpec) withDefaults(z *ZookeeperCluster) (changed bool) 
 			},
 		}
 		changed = true
+	} else {
+		var foundClient, foundQuorum, foundLeader, foundMetrics bool
+		for i := 0; i < len(s.Ports); i++ {
+			if s.Ports[i].Name == "client" {
+				foundClient = true
+			} else if s.Ports[i].Name == "quorum" {
+				foundQuorum = true
+			} else if s.Ports[i].Name == "leader-election" {
+				foundLeader = true
+			} else if s.Ports[i].Name == "metrics" {
+				foundMetrics = true
+			}
+		}
+		if !foundClient {
+			ports := v1.ContainerPort{Name: "client", ContainerPort: 2181}
+			s.Ports = append(s.Ports, ports)
+			changed = true
+		}
+		if !foundQuorum {
+			ports := v1.ContainerPort{Name: "quorum", ContainerPort: 2888}
+			s.Ports = append(s.Ports, ports)
+			changed = true
+		}
+		if !foundLeader {
+			ports := v1.ContainerPort{Name: "leader-election", ContainerPort: 3888}
+			s.Ports = append(s.Ports, ports)
+			changed = true
+		}
+		if !foundMetrics {
+			ports := v1.ContainerPort{Name: "metrics", ContainerPort: 7000}
+			s.Ports = append(s.Ports, ports)
+			changed = true
+		}
 	}
+
 	if z.Spec.Labels == nil {
 		z.Spec.Labels = map[string]string{}
 		changed = true

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types_test.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/pravega/zookeeper-operator/pkg/apis/zookeeper/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -229,6 +230,42 @@ var _ = Describe("ZookeeperCluster Types", func() {
 			p = z.ZookeeperPorts()
 		})
 
+		It("should have a client port", func() {
+			Ω(p.Client).To(BeEquivalentTo(2181))
+		})
+
+		It("should have a quorum port", func() {
+			Ω(p.Quorum).To(BeEquivalentTo(2888))
+		})
+
+		It("should have a leader port", func() {
+			Ω(p.Leader).To(BeEquivalentTo(3888))
+		})
+
+		It("should have a metrics port", func() {
+			Ω(p.Metrics).To(BeEquivalentTo(7000))
+		})
+	})
+	Context("#ZookeeperPorts with values set", func() {
+		var p v1beta1.Ports
+		BeforeEach(func() {
+			ports := []v1.ContainerPort{
+				{
+					Name:          "testclient",
+					ContainerPort: 2181,
+				},
+			}
+			z = v1beta1.ZookeeperCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "example",
+				},
+				Spec: v1beta1.ZookeeperClusterSpec{
+					Ports: ports,
+				},
+			}
+			z.WithDefaults()
+			p = z.ZookeeperPorts()
+		})
 		It("should have a client port", func() {
 			Ω(p.Client).To(BeEquivalentTo(2181))
 		})


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description
With recent changes we have added metrics ports. While doing upgrade, metrics port is not set to a default value because in `withDefaults` we are only checking ports are not present. we were not checking for individual ports for client, quorum, leader-election and metrics are present. Due to this reconcile was failing.
### Purpose of the change

 Fixes #204

### What the code does

In case we have not specified all the ports in zookeeper cluster manifest,  in `withDefaults`  method, we will set the missing ports to default.

### How to verify it

1. Verified zookeeper cluster status is set properly in case of upgrade
2. Verified by not giving client ports in the zk manifest, and client port is setting to default.
