### PR TITLE
Issue 206: Zookeeper cluster upgrade is taking more time 

### DIFF
--- a/docker/bin/zookeeperTeardown.sh
+++ b/docker/bin/zookeeperTeardown.sh
@@ -21,7 +21,7 @@ LOG4J_CONF=/conf/log4j-quiet.properties
 # Wait for client connections to drain. Kubernetes will wait until the confiugred
 # "terminationGracePeriodSeconds" before focibly killing the container
 CONN_COUNT=`echo cons | nc localhost 2181 | grep -v "^$" |grep -v "/127.0.0.1:" | wc -l`
-for (( i = 0; i < 36; i++ )); do
+for (( i = 0; i < 6; i++ )); do
   if [[ "$CONN_COUNT" -gt 0 ]]; then
     echo "$CONN_COUNT non-local connections still connected."
     sleep 5

--- a/pkg/apis/zookeeper/v1beta1/deepcopy_test.go
+++ b/pkg/apis/zookeeper/v1beta1/deepcopy_test.go
@@ -108,11 +108,11 @@ var _ = Describe("ZookeeperCluster DeepCopy", func() {
 		It("value of str7 should be 2000", func() {
 			Ω(str7).To(Equal("2000"))
 		})
-		It("value of str8 should be 180", func() {
-			Ω(str8).To(Equal("180"))
+		It("value of str8 should be 30", func() {
+			Ω(str8).To(Equal("30"))
 		})
-		It("value of str9 should be 180", func() {
-			Ω(str9).To(Equal("180"))
+		It("value of str9 should be 30", func() {
+			Ω(str9).To(Equal("30"))
 		})
 		It("value of str10 should be zk-2", func() {
 			Ω(str10).To(Equal("zk-2"))

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -33,7 +33,7 @@ const (
 	// DefaultTerminationGracePeriod is the default time given before the
 	// container is stopped. This gives clients time to disconnect from a
 	// specific node gracefully.
-	DefaultTerminationGracePeriod = 180
+	DefaultTerminationGracePeriod = 30
 
 	// DefaultZookeeperCacheVolumeSize is the default volume size for the
 	// Zookeeper cache volume
@@ -285,7 +285,7 @@ type PodPolicy struct {
 
 	// TerminationGracePeriodSeconds is the amount of time that kubernetes will
 	// give for a pod instance to shutdown normally.
-	// The default value is 180.
+	// The default value is 30.
 	TerminationGracePeriodSeconds int64 `json:"terminationGracePeriodSeconds"`
 }
 


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description
Reverted termination grace period to 30s , as it causes delay in upgrade and deletion of pods if there are client connections.

### Purpose of the change

Fixes #206

### What the code does

Reverted termination grace period to 30s and teardown script, reduce the time for client connections to terminate from 180s to 30s
### How to verify it

Verified that upgrade of pods is completing with in a minute.
