### PR TITLE
Issue 209: Not able to create zookeeper cluster resources via exporter binary

### DIFF
--- a/pkg/controller/zookeepercluster/zookeepercluster_controller.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller.go
@@ -560,20 +560,16 @@ func (r *ReconcileZookeeperCluster) GenerateYAML(inst *zookeeperv1beta1.Zookeepe
 // yamlStatefulSet will generates YAML file for StatefulSet
 func (r *ReconcileZookeeperCluster) yamlStatefulSet(instance *zookeeperv1beta1.ZookeeperCluster) (err error) {
 	sts := zk.MakeStatefulSet(instance)
-	if err = controllerutil.SetControllerReference(instance, sts, r.scheme); err != nil {
-		return err
-	}
-	subdir, err := yamlexporter.CreateOutputSubDir(sts.OwnerReferences[0].Kind, sts.Labels["component"])
+
+	subdir, err := yamlexporter.CreateOutputSubDir("ZookeeperCluster", sts.Labels["component"])
 	return yamlexporter.GenerateOutputYAMLFile(subdir, sts.Kind, sts)
 }
 
 // yamlClientService will generates YAML file for zookeeper client service
 func (r *ReconcileZookeeperCluster) yamlClientService(instance *zookeeperv1beta1.ZookeeperCluster) (err error) {
 	svc := zk.MakeClientService(instance)
-	if err = controllerutil.SetControllerReference(instance, svc, r.scheme); err != nil {
-		return err
-	}
-	subdir, err := yamlexporter.CreateOutputSubDir(svc.OwnerReferences[0].Kind, "client")
+
+	subdir, err := yamlexporter.CreateOutputSubDir("ZookeeperCluster", "client")
 	if err != nil {
 		return err
 	}
@@ -583,10 +579,8 @@ func (r *ReconcileZookeeperCluster) yamlClientService(instance *zookeeperv1beta1
 // yamlHeadlessService will generates YAML file for zookeeper headless service
 func (r *ReconcileZookeeperCluster) yamlHeadlessService(instance *zookeeperv1beta1.ZookeeperCluster) (err error) {
 	svc := zk.MakeHeadlessService(instance)
-	if err = controllerutil.SetControllerReference(instance, svc, r.scheme); err != nil {
-		return err
-	}
-	subdir, err := yamlexporter.CreateOutputSubDir(svc.OwnerReferences[0].Kind, "headless")
+
+	subdir, err := yamlexporter.CreateOutputSubDir("ZookeeperCluster", "headless")
 	if err != nil {
 		return err
 	}
@@ -596,10 +590,8 @@ func (r *ReconcileZookeeperCluster) yamlHeadlessService(instance *zookeeperv1bet
 // yamlPodDisruptionBudget will generates YAML file for zookeeper PDB
 func (r *ReconcileZookeeperCluster) yamlPodDisruptionBudget(instance *zookeeperv1beta1.ZookeeperCluster) (err error) {
 	pdb := zk.MakePodDisruptionBudget(instance)
-	if err = controllerutil.SetControllerReference(instance, pdb, r.scheme); err != nil {
-		return err
-	}
-	subdir, err := yamlexporter.CreateOutputSubDir(pdb.OwnerReferences[0].Kind, "pdb")
+
+	subdir, err := yamlexporter.CreateOutputSubDir("ZookeeperCluster", "pdb")
 	if err != nil {
 		return err
 	}
@@ -609,10 +601,8 @@ func (r *ReconcileZookeeperCluster) yamlPodDisruptionBudget(instance *zookeeperv
 // yamlConfigMap will generates YAML file for Zookeeper configmap
 func (r *ReconcileZookeeperCluster) yamlConfigMap(instance *zookeeperv1beta1.ZookeeperCluster) (err error) {
 	cm := zk.MakeConfigMap(instance)
-	if err = controllerutil.SetControllerReference(instance, cm, r.scheme); err != nil {
-		return err
-	}
-	subdir, err := yamlexporter.CreateOutputSubDir(cm.OwnerReferences[0].Kind, "config")
+
+	subdir, err := yamlexporter.CreateOutputSubDir("ZookeeperCluster", "config")
 	if err != nil {
 		return err
 	}

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -21,7 +21,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -269,13 +268,7 @@ func makeService(name string, ports []v1.ServicePort, clusterIP bool, z *v1beta1
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: z.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(z, schema.GroupVersionKind{
-					Group:   v1beta1.SchemeGroupVersion.Group,
-					Version: v1beta1.SchemeGroupVersion.Version,
-					Kind:    "ZookeeperCluster",
-				}),
-			},
+
 			Labels:      map[string]string{"app": z.GetName(), "headless": strconv.FormatBool(!clusterIP)},
 			Annotations: annotationMap,
 		},
@@ -301,13 +294,6 @@ func MakePodDisruptionBudget(z *v1beta1.ZookeeperCluster) *policyv1beta1.PodDisr
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      z.GetName(),
 			Namespace: z.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(z, schema.GroupVersionKind{
-					Group:   v1beta1.SchemeGroupVersion.Group,
-					Version: v1beta1.SchemeGroupVersion.Version,
-					Kind:    "ZookeeperCluster",
-				}),
-			},
 		},
 		Spec: policyv1beta1.PodDisruptionBudgetSpec{
 			MaxUnavailable: &pdbCount,


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description

Currently, zookeeper exporter generates the  secondary resources( stateful set, pdb, config map, headless and cliene service) with owner reference set to primary resources . But the primary resource is not created by the exporter.  Due to this while creating the resources using the manifests generated by exporter it is failing.
### Purpose of the change

 Fixes #209

### What the code does

Removed the owner reference while creating headless service, client service, pdb, config map and stateful set

### How to verify it

Verified  creating the zookeeper cluster using the yaml files generated by the exporter
Also verified zookeeper cluster deployment via operator
