### PR TITLE
Issue 217: Manifests for minikube installation using charts

### DIFF
--- a/charts/zookeeper/values/minikube.yaml
+++ b/charts/zookeeper/values/minikube.yaml
@@ -1,0 +1,8 @@
+replicas: 1
+
+persistence:
+  storageClassName: standard
+  ## specifying reclaim policy for PersistentVolumes
+  ## accepted values - Delete / Retain
+  reclaimPolicy: Delete
+  volumeSize: 10Gi


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Provides a sample manifest for a minikube environment would make it much easier for users to install a zookeeper cluster on minikube  with the required number of component replicas, resources and required options without having to override any of the values.

### Purpose of the change
Fixes #217 

### How to verify it
To install a cluster with the resource requirements that would work on a minikube environment, use the following command
```
helm install zookeeper charts/zookeeper --values charts/zookeeper/values/minikube.yaml
```
It will successfully install a zookeeper cluster with the required replicas, resources and options.
