### PR TITLE
Issue 217: Manifests for minikube installation using charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The project is currently alpha. While no breaking API changes are currently plan
     * [Direct Access to Cluster](#direct-access-to-the-cluster)
     * [Run the Operator Locally](#run-the-operator-locally)
     * [Installation on GKE](#installation-on-google-kubernetes-engine)
-
+    * [Installation on Minikube](#installation-on-minikube)
 
 
 ### Overview
@@ -304,6 +304,21 @@ On GKE, the following command must be run before installing the operator, replac
 
 ```
 $ kubectl create clusterrolebinding your-user-cluster-admin-binding --clusterrole=cluster-admin --user=your.google.cloud.email@example.org
+```
+
+### Installation on Minikube
+
+#### Minikube Setup
+To setup minikube locally you can follow the steps mentioned [here](https://github.com/pravega/pravega/wiki/Kubernetes-Based-System-Test-Framework#minikube-setup).
+
+Once minikube setup is complete, `minikube start` will create a minikube VM.
+
+#### Cluster Deployment
+First install the zookeeper operator in either of the ways mentioned [here](#install-the-operator).
+Since minikube provides a single node Kubernetes cluster which has a low resource provisioning, we provide a simple way to install a small zookeeper cluster on a minikube environment using the following command.
+
+```
+helm install zookeeper charts/zookeeper --values charts/zookeeper/values/minikube.yaml
 ```
 
 #### Zookeeper YAML  Exporter

--- a/charts/zookeeper/values/minikube.yaml
+++ b/charts/zookeeper/values/minikube.yaml
@@ -1,0 +1,8 @@
+replicas: 1
+
+persistence:
+  storageClassName: standard
+  ## specifying reclaim policy for PersistentVolumes
+  ## accepted values - Delete / Retain
+  reclaimPolicy: Delete
+  volumeSize: 10Gi


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Provides a sample manifest for a minikube environment would make it much easier for users to install a zookeeper cluster on minikube  with the required number of component replicas, resources and required options without having to override any of the values.

### Purpose of the change
Fixes #217 

### How to verify it
To install a cluster with the resource requirements that would work on a minikube environment, use the following command
```
helm install zookeeper charts/zookeeper --values charts/zookeeper/values/minikube.yaml
```
It will successfully install a zookeeper cluster with the required replicas, resources and options.