### PR TITLE
ZooKeeper Operator API Resource Hook.

### DIFF
--- a/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
+++ b/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
@@ -69,7 +69,7 @@ data:
     set -e
     sleep 30
 
-    if [ -z "$(kubectl api-resources | grep zk)" ]; then
+    if [ -z "$(kubectl api-resources | grep ZookeeperCluster)" ]; then
         exit 1
     fi
 ---
@@ -84,7 +84,7 @@ metadata:
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
 spec:
-  backoffLimit: 3
+  backoffLimit: {{ .Values.hooks.backoffLimit }}
   template:
     metadata:
       name: {{ template "zookeeper-operator.fullname" . }}-post-install-upgrade

--- a/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
+++ b/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
@@ -73,16 +73,12 @@ data:
         exit 1
     fi
 
-    replicas=`kubectl get deployment {{ template "zookeeper-operator.fullname" . }} \
-      -n {{ .Release.Namespace }} \
-      -o jsonpath='{.status.replicas}'`
     readyReplicas=`kubectl get deployment {{ template "zookeeper-operator.fullname" . }} \
       -n {{ .Release.Namespace }} \
       -o jsonpath='{.status.readyReplicas}'`
-    echo "ZookeeperCluster replicas: $replicas"
     echo "ZookeeperCluster readyReplicas: $readyReplicas"
 
-    if [ $readyReplicas != $replicas ]; then
+    if [ -z $readyReplicas ] || [ $readyReplicas -le 0 ]; then
         exit 1
     fi
 ---

--- a/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
+++ b/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
@@ -63,7 +63,13 @@ data:
     set -e
     sleep 30
 
-    if [ -z "$(kubectl api-resources | grep zookeeperclusters)" ]; then
+    if [ -z "$(kubectl api-resources | grep zk)" ]; then
+        exit 1
+    fi
+
+    replicas=`kubectl get zk -n {{ .Release.Namespace }} {{ template "zookeeper-operator.fullname" . }} -o jsonpath='{.status.replicas}'`
+    readyReplicas=`kubectl get zk -n {{ .Release.Namespace }} {{ template "zookeeper-operator.fullname" . }} -o jsonpath='{.status.readyReplicas}'
+    if [ $readyReplicas != $replicas ]; then
         exit 1
     fi
 ---
@@ -78,7 +84,7 @@ metadata:
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
 spec:
-  backoffLimit: 10
+  backoffLimit: 3
   template:
     metadata:
       name: {{ template "zookeeper-operator.fullname" . }}-post-install-upgrade

--- a/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
+++ b/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
@@ -72,15 +72,6 @@ data:
     if [ -z "$(kubectl api-resources | grep zk)" ]; then
         exit 1
     fi
-
-    readyReplicas=`kubectl get deployment {{ template "zookeeper-operator.fullname" . }} \
-      -n {{ .Release.Namespace }} \
-      -o jsonpath='{.status.readyReplicas}'`
-    echo "ZookeeperCluster readyReplicas: $readyReplicas"
-
-    if [ -z $readyReplicas ] || [ $readyReplicas -le 0 ]; then
-        exit 1
-    fi
 ---
 
 apiVersion: batch/v1

--- a/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
+++ b/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
@@ -1,0 +1,101 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "zookeeper-operator.fullname" . }}-post-install-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+rules:
+- apiGroups:
+  - zookeeper.pravega.io
+  resources:
+  - "*"
+  verbs:
+  - get
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "zookeeper-operator.fullname" . }}-post-install-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+subjects:
+- kind: ServiceAccount
+  name: {{ template "zookeeper-operator.fullname" . }}-post-install-upgrade
+  namespace: {{.Release.Namespace}}
+roleRef:
+  kind: Role
+  name: {{ template "zookeeper-operator.fullname" . }}-post-install-upgrade
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "zookeeper-operator.fullname" . }}-post-install-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "zookeeper-operator.fullname" . }}-post-install-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+      "helm.sh/hook": post-install, post-upgrade
+      "helm.sh/hook-weight": "1"
+      "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+data:
+  validations.sh: |
+    #!/bin/sh
+    set -e
+    sleep 30
+
+    if [ -z "$(kubectl api-resources | grep zookeeperclusters)" ]; then
+        exit 1
+    fi
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "zookeeper-operator.fullname" . }}-post-install-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+      name: {{ template "zookeeper-operator.fullname" . }}-post-install-upgrade
+    spec:
+      serviceAccountName: {{ template "zookeeper-operator.fullname" . }}-post-install-upgrade
+      restartPolicy: Never
+      containers:
+      - name: post-install-upgrade-job
+        image: "{{ .Values.hooks.image.repository }}:{{ .Values.hooks.image.tag }}"
+        command:
+          - /scripts/validations.sh
+        volumeMounts:
+          - name: sh
+            mountPath: /scripts
+            readOnly: true
+      volumes:
+        - name: sh
+          configMap:
+            name: {{ template "zookeeper-operator.fullname" . }}-post-install-upgrade
+            defaultMode: 0555

--- a/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
+++ b/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
@@ -14,6 +14,12 @@ rules:
   - "*"
   verbs:
   - get
+- apiGroups:
+  - extensions
+  resources:
+  - "deployments"
+  verbs:
+  - get
 ---
 
 kind: RoleBinding
@@ -67,8 +73,15 @@ data:
         exit 1
     fi
 
-    replicas=`kubectl get zk -n {{ .Release.Namespace }} {{ template "zookeeper-operator.fullname" . }} -o jsonpath='{.status.replicas}'`
-    readyReplicas=`kubectl get zk -n {{ .Release.Namespace }} {{ template "zookeeper-operator.fullname" . }} -o jsonpath='{.status.readyReplicas}'
+    replicas=`kubectl get deployment {{ template "zookeeper-operator.fullname" . }} \
+      -n {{ .Release.Namespace }} \
+      -o jsonpath='{.status.replicas}'`
+    readyReplicas=`kubectl get deployment {{ template "zookeeper-operator.fullname" . }} \
+      -n {{ .Release.Namespace }} \
+      -o jsonpath='{.status.readyReplicas}'`
+    echo "ZookeeperCluster replicas: $replicas"
+    echo "ZookeeperCluster readyReplicas: $readyReplicas"
+
     if [ $readyReplicas != $replicas ]; then
         exit 1
     fi

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -44,3 +44,4 @@ hooks:
   image:
     repository: lachlanevenson/k8s-kubectl
     tag: v1.16.10
+

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -41,6 +41,7 @@ resources: {}
   #   memory: 128Mi
 
 hooks:
+  backoffLimit: 10
   image:
     repository: lachlanevenson/k8s-kubectl
     tag: v1.16.10

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -39,3 +39,8 @@ resources: {}
   # requests:
   #   cpu: 1
   #   memory: 128Mi
+
+hooks:
+  image:
+    repository: lachlanevenson/k8s-kubectl
+    tag: v1.16.10


### PR DESCRIPTION
### Change log description

* Adds a manifest which defines a post-install/upgrade hook to make sure the `zookeepercluster` resource exists.

### Purpose of the change

* If one is unlucky with the timings when install the `zookeeper-operator` chart, directly followed by the `zookeeper` chart, the api-resource `ZooKeeperCluster` may not exist by the time the zookeeper chart tries to create a `ZooKeeperCluster`.

### What the code does

* See above.

### How to verify it

Run many install/uninstall cycles of the mentioned charts -- see that the zookeeper chart does not start before its resource dependency is registered.
