### PR TITLE
Issue 222: zoo.cfg updated parameters are not picked up during rolling restarts

### DIFF
--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -144,14 +144,17 @@ fi
 
 ZOOCFGDIR=/data/conf
 export ZOOCFGDIR
+echo Copying /conf contents to writable directory, to support Zookeeper dynamic reconfiguration
 if [[ ! -d "$ZOOCFGDIR" ]]; then
-  echo Copying /conf contents to writable directory, to support Zookeeper dynamic reconfiguration
   mkdir $ZOOCFGDIR
   cp -f /conf/zoo.cfg $ZOOCFGDIR
-  cp -f /conf/log4j.properties $ZOOCFGDIR
-  cp -f /conf/log4j-quiet.properties $ZOOCFGDIR
-  cp -f /conf/env.sh $ZOOCFGDIR
+else
+  echo Copying the /conf/zoo.cfg contents except the dynamic config file during restart
+  echo -e "$( head -n -1 /conf/zoo.cfg )""\n""$( tail -n 1 "$STATIC_CONFIG" )" > $STATIC_CONFIG
 fi
+cp -f /conf/log4j.properties $ZOOCFGDIR
+cp -f /conf/log4j-quiet.properties $ZOOCFGDIR
+cp -f /conf/env.sh $ZOOCFGDIR
 
 if [ -f $DYNCONFIG ]; then
   # Node registered, start server


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description

We were copying zoo.cfg file from /conf directory to /data/conf.cfg only at the start. If any configuration parameters are changed after installation, it was not taking into effect.

### Purpose of the change

 Fixes #222

### What the code does

Modified the start up script such a way that /conf/zoo.cfg contents are copied to  /data/conf.cfg even on restart. Will retain the dynamicconfig file in /data/conf.cfg

### How to verify it

Verified by changing the config parameters and saw that they are getting updated on rolling restarts.