### PR TITLE
Issue 241: Chart changes and CRD refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ The operator itself is built with the [Operator framework](https://github.com/op
 
 ## Usage
 
-We recommend using our [helm charts](charts) for all installation and upgrades. However there are manual deployment and upgrade options available as well.
+We recommend using our [helm charts](charts) for all installation and upgrades. Since version 0.2.8 onwards, the helm charts for zookeeper operator and zookeeper cluster are published in [https://charts.pravega.io/](https://charts.pravega.io/). To add this repository to your Helm repos, use the following command
+```
+helm repo add pravega https://charts.pravega.io
+```
+However there are manual deployment and upgrade options available as well.
 
 ### Install the operator
 
@@ -44,11 +48,7 @@ We recommend using our [helm charts](charts) for all installation and upgrades. 
 
 #### Install via helm
 
-Use helm to quickly deploy a zookeeper operator with the release name `zookeeper-operator`.
-
-```
-$ helm install zookeeper-operator charts/zookeeper-operator
-```
+To understand how to deploy the zookeeper operator using helm, refer to [this](charts/zookeeper-operator#installing-the-chart).
 
 #### Manual deployment
 
@@ -92,13 +92,7 @@ zookeeper-operator   1         1         1            1           12m
 
 #### Install via helm
 
-Helm can be used to install a sample zookeeper cluster with the release name `zookeeper`.
-
-```
-$ helm install zookeeper charts/zookeeper
-```
-
-Check out the [zookeeper helm charts](charts/zookeeper) for the complete list of configurable parameters.
+To understand how to deploy a sample zookeeper cluster using helm, refer to [this](charts/zookeeper#installing-the-chart).
 
 #### Manual deployment
 
@@ -213,11 +207,7 @@ $ kubectl create -f zk-with-istio.yaml
 
 #### Trigger the upgrade via helm
 
-The upgrade can be triggered via helm using the following command
-```
-$ helm upgrade zookeeper <location of modified charts> --timeout 600s
-```
-Here `zookeeper` is the release name of the zookeeper cluster.
+To understand how to upgrade the zookeeper cluster using helm, refer to [this](charts/zookeeper#upgrading-the-chart).
 
 #### Trigger the upgrade manually
 
@@ -282,10 +272,7 @@ Status:
 
 #### Uninstall via helm
 
-```
-$ helm uninstall zookeeper
-```
-Here `zookeeper` is the zookeeper cluster release name.
+Refer to [this](charts/zookeeper#uninstalling-the-chart).
 
 #### Manual uninstall
 
@@ -299,10 +286,7 @@ $ kubectl delete -f zk.yaml
 
 #### Uninstall via helm
 
-```
-$ helm uninstall zookeeper-operator
-```
-Here `zookeeper-operator` is the operator release name.
+Refer to [this](charts/zookeeper-operator#uninstalling-the-chart).
 
 #### Manual uninstall
 

--- a/charts/zookeeper-operator/README.md
+++ b/charts/zookeeper-operator/README.md
@@ -8,21 +8,24 @@ This chart bootstraps a [Zookeeper Operator](https://github.com/pravega/zookeepe
 
 ## Prerequisites
   - Kubernetes 1.15+ with Beta APIs
-  - Helm 3+
+  - Helm 3.2.1+
 
 ## Installing the Chart
 
 To install the chart with the release name `my-release`:
 
 ```
-$ helm install my-release zookeeper-operator
+$ helm repo add pravega https://charts.pravega.io
+$ helm repo update
+$ helm install my-release pravega/zookeeper-operator --version=`version`
 ```
+Note: `version` can be any stable release version for zookeeper operator from 0.2.8 onwards.
 
 The command deploys zookeeper-operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
 ## Uninstalling the Chart
 
-To uninstall/delete the `my-release` deployment:
+To uninstall/delete the deployment `my-release`:
 
 ```
 $ helm uninstall my-release

--- a/charts/zookeeper-operator/README.md
+++ b/charts/zookeeper-operator/README.md
@@ -39,6 +39,7 @@ The following table lists the configurable parameters of the Zookeeper operator 
 | `image.repository` | Image repository | `pravega/zookeeper-operator` |
 | `image.tag` | Image tag | `0.2.8` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `crd.create` | Create zookeeper CRD | `true` |
 | `rbac.create` | Create RBAC resources | `true` |
 | `serviceAccount.create` | Create service account | `true` |
 | `serviceAccount.name` | Name for the service account | `zookeeper-operator` |

--- a/charts/zookeeper-operator/templates/operator.yaml
+++ b/charts/zookeeper-operator/templates/operator.yaml
@@ -35,5 +35,19 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: {{ template "zookeeper-operator.fullname" . }}
+        {{- if .Values.resources }}
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+          {{ toYaml .Values.resources | nindent 10 }}
+        {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{ toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{ toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{ toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}

--- a/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
+++ b/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
@@ -105,3 +105,15 @@ spec:
           configMap:
             name: {{ template "zookeeper-operator.fullname" . }}-post-install-upgrade
             defaultMode: 0555
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}

--- a/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -2,11 +2,37 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
-  creationTimestamp: null
   name: zookeeperclusters.zookeeper.pravega.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.replicas
+    description: The number of ZooKeeper servers in the ensemble
+    name: Replicas
+    type: integer
+  - JSONPath: .status.readyReplicas
+    description: The number of ZooKeeper servers in the ensemble that are in a Ready
+      state
+    name: Ready Replicas
+    type: integer
+  - JSONPath: .status.currentVersion
+    description: The current Zookeeper version
+    name: Version
+    type: string
+  - JSONPath: .spec.image.tag
+    description: The desired Zookeeper version
+    name: Desired Version
+    type: string
+  - JSONPath: .status.internalClientEndpoint
+    description: Client endpoint internal to cluster network
+    name: Internal Endpoint
+    type: string
+  - JSONPath: .status.externalClientEndpoint
+    description: Client endpoint external to cluster network via LoadBalancer
+    name: External Endpoint
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: zookeeper.pravega.io
   names:
     kind: ZookeeperCluster
@@ -15,34 +41,6 @@ spec:
     shortNames:
     - zk
     singular: zookeepercluster
-  additionalPrinterColumns:
-  - name: Replicas
-    type: integer
-    description: The number of ZooKeeper servers in the ensemble
-    JSONPath: .spec.replicas
-  - name: Ready Replicas
-    type: integer
-    description: The number of ZooKeeper servers in the ensemble that are in a Ready state
-    JSONPath: .status.readyReplicas
-  - name: Version
-    type: string
-    description: The current Zookeeper version
-    JSONPath: .status.currentVersion
-  - name: Desired Version
-    type: string
-    description: The desired Zookeeper version
-    JSONPath: .spec.image.tag
-  - name: Internal Endpoint
-    type: string
-    description: Client endpoint internal to cluster network
-    JSONPath: .status.internalClientEndpoint
-  - name: External Endpoint
-    type: string
-    description: Client endpoint external to cluster network via LoadBalancer
-    JSONPath: .status.externalClientEndpoint
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
   scope: Namespaced
   subresources:
     status: {}
@@ -94,6 +92,1056 @@ spec:
                     \n The default value is 2000."
                   type: integer
               type: object
+            containers:
+              description: Containers defines to support multi containers
+              items:
+                description: A single application container that you want to run within
+                  a pod.
+                properties:
+                  args:
+                    description: 'Arguments to the entrypoint. The docker image''s
+                      CMD is used if this is not provided. Variable references $(VAR_NAME)
+                      are expanded using the container''s environment. If a variable
+                      cannot be resolved, the reference in the input string will be
+                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                      regardless of whether the variable exists or not. Cannot be
+                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: 'Entrypoint array. Not executed within a shell. The
+                      docker image''s ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container''s
+                      environment. If a variable cannot be resolved, the reference
+                      in the input string will be unchanged. The $(VAR_NAME) syntax
+                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                      will never be expanded, regardless of whether the variable exists
+                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, metadata.labels, metadata.annotations,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP,
+                                status.podIP, status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: List of sources to populate environment variables
+                      in the container. The keys defined within a source must be a
+                      C_IDENTIFIER. All invalid keys will be reported as an event
+                      when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take
+                      precedence. Values defined by an Env with a duplicate key will
+                      take precedence. Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
+                  image:
+                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management
+                      to default or override container images in workload controllers
+                      like Deployments and StatefulSets.'
+                    type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent
+                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                  lifecycle:
+                    description: Actions that the management system should take in
+                      response to container lifecycle events. Cannot be updated.
+                    properties:
+                      postStart:
+                        description: 'PostStart is called immediately after a container
+                          is created. If the handler fails, the container is terminated
+                          and restarted according to its restart policy. Other management
+                          of the container blocks until the hook completes. More info:
+                          https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                        properties:
+                          exec:
+                            description: One and only one of the following should
+                              be specified. Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      preStop:
+                        description: 'PreStop is called immediately before a container
+                          is terminated due to an API request or management event
+                          such as liveness/startup probe failure, preemption, resource
+                          contention, etc. The handler is not called if the container
+                          crashes or exits. The reason for termination is passed to
+                          the handler. The Pod''s termination grace period countdown
+                          begins before the PreStop hooked is executed. Regardless
+                          of the outcome of the handler, the container will eventually
+                          terminate within the Pod''s termination grace period. Other
+                          management of the container blocks until the hook completes
+                          or until the termination grace period is reached. More info:
+                          https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                        properties:
+                          exec:
+                            description: One and only one of the following should
+                              be specified. Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                    type: object
+                  livenessProbe:
+                    description: 'Periodic probe of container liveness. Container
+                      will be restarted if the probe fails. Cannot be updated. More
+                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    properties:
+                      exec:
+                        description: One and only one of the following should be specified.
+                          Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness and startup. Minimum value is
+                          1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: 'TCPSocket specifies an action involving a TCP
+                          port. TCP hooks not yet supported TODO: implement a realistic
+                          TCP lifecycle hook'
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  name:
+                    description: Name of the container specified as a DNS_LABEL. Each
+                      container in a pod must have a unique name (DNS_LABEL). Cannot
+                      be updated.
+                    type: string
+                  ports:
+                    description: List of ports to expose from the container. Exposing
+                      a port here gives the system additional information about the
+                      network connections a container uses, but is primarily informational.
+                      Not specifying a port here DOES NOT prevent that port from being
+                      exposed. Any port which is listening on the default "0.0.0.0"
+                      address inside a container will be accessible from the network.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: Number of port to expose on the host. If specified,
+                            this must be a valid port number, 0 < x < 65536. If HostNetwork
+                            is specified, this must match ContainerPort. Most containers
+                            do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: If specified, this must be an IANA_SVC_NAME
+                            and unique within the pod. Each named port in a pod must
+                            have a unique name. Name for the port that can be referred
+                            to by services.
+                          type: string
+                        protocol:
+                          description: Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerPort
+                    - protocol
+                    x-kubernetes-list-type: map
+                  readinessProbe:
+                    description: 'Periodic probe of container service readiness. Container
+                      will be removed from service endpoints if the probe fails. Cannot
+                      be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    properties:
+                      exec:
+                        description: One and only one of the following should be specified.
+                          Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness and startup. Minimum value is
+                          1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: 'TCPSocket specifies an action involving a TCP
+                          port. TCP hooks not yet supported TODO: implement a realistic
+                          TCP lifecycle hook'
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  resources:
+                    description: 'Compute Resources required by this container. Cannot
+                      be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  securityContext:
+                    description: 'Security options the pod should run with. More info:
+                      https://kubernetes.io/docs/concepts/policy/security-context/
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. This field is beta-level and may be
+                              disabled with the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
+                    type: object
+                  startupProbe:
+                    description: 'StartupProbe indicates that the Pod has successfully
+                      initialized. If specified, no other probes are executed until
+                      this completes successfully. If this probe fails, the Pod will
+                      be restarted, just as if the livenessProbe failed. This can
+                      be used to provide different probe parameters at the beginning
+                      of a Pod''s lifecycle, when it might take a long time to load
+                      data or warm a cache, than during steady-state operation. This
+                      cannot be updated. This is an alpha feature enabled by the StartupProbe
+                      feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    properties:
+                      exec:
+                        description: One and only one of the following should be specified.
+                          Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness and startup. Minimum value is
+                          1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: 'TCPSocket specifies an action involving a TCP
+                          port. TCP hooks not yet supported TODO: implement a realistic
+                          TCP lifecycle hook'
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  stdin:
+                    description: Whether this container should allocate a buffer for
+                      stdin in the container runtime. If this is not set, reads from
+                      stdin in the container will always result in EOF. Default is
+                      false.
+                    type: boolean
+                  stdinOnce:
+                    description: Whether the container runtime should close the stdin
+                      channel after it has been opened by a single attach. When stdin
+                      is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container
+                      start, is empty until the first client attaches to stdin, and
+                      then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container
+                      is restarted. If this flag is false, a container processes that
+                      reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s
+                      termination message will be written is mounted into the container''s
+                      filesystem. Message written is intended to be brief final status,
+                      such as an assertion failure message. Will be truncated by the
+                      node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                      Cannot be updated.'
+                    type: string
+                  terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated.
+                      File will use the contents of terminationMessagePath to populate
+                      the container status message on both success and failure. FallbackToLogsOnError
+                      will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever
+                      is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                  tty:
+                    description: Whether this container should allocate a TTY for
+                      itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container. This is a beta feature.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - devicePath
+                      - name
+                      type: object
+                    type: array
+                  volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            around. When not set, MountPropagationNone is used. This
+                            field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted. Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: Expanded path within the volume from which
+                            the container's volume should be mounted. Behaves similarly
+                            to SubPath but environment variable references $(VAR_NAME)
+                            are expanded using the container's environment. Defaults
+                            to "" (volume's root). SubPathExpr and SubPath are mutually
+                            exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                  workingDir:
+                    description: Container's working directory. If not specified,
+                      the container runtime's default will be used, which might be
+                      configured in the container image. Cannot be updated.
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
             domainName:
               description: External host name appended for dns annotation
               type: string
@@ -136,9 +1184,9 @@ spec:
                   description: PullPolicy describes a policy for if/when to pull a
                     container image
                   enum:
-                    - Always
-                    - Never
-                    - IfNotPresent
+                  - Always
+                  - Never
+                  - IfNotPresent
                   type: string
                 repository:
                   type: string
@@ -165,8 +1213,8 @@ spec:
                     by the operator when zookeeper cluster is deleted. The default
                     value is Retain.
                   enum:
-                    - Delete
-                    - Retain
+                  - Delete
+                  - Retain
                   type: string
                 spec:
                   description: PersistentVolumeClaimSpec is the spec to describe PVC
@@ -178,9 +1226,9 @@ spec:
                         the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                       items:
                         enum:
-                          - ReadWriteOnce
-                          - ReadOnlyMany
-                          - ReadWriteMany
+                        - ReadWriteOnce
+                        - ReadOnlyMany
+                        - ReadWriteMany
                         type: string
                       type: array
                     dataSource:
@@ -258,10 +1306,10 @@ spec:
                                   to a set of values. Valid operators are In, NotIn,
                                   Exists and DoesNotExist.
                                 enum:
-                                    - In
-                                    - NotIn
-                                    - Exists
-                                    - DoesNotExist
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
                                 type: string
                               values:
                                 description: values is an array of string values.
@@ -353,12 +1401,12 @@ spec:
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
                                           enum:
-                                            - In
-                                            - NotIn
-                                            - Exists
-                                            - DoesNotExist
-                                            - Gt
-                                            - Lt
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          - Gt
+                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -396,12 +1444,12 @@ spec:
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
                                           enum:
-                                            - In
-                                            - NotIn
-                                            - Exists
-                                            - DoesNotExist
-                                            - Gt
-                                            - Lt
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          - Gt
+                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -468,12 +1516,12 @@ spec:
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
                                           enum:
-                                            - In
-                                            - NotIn
-                                            - Exists
-                                            - DoesNotExist
-                                            - Gt
-                                            - Lt
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          - Gt
+                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -511,12 +1559,12 @@ spec:
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
                                           enum:
-                                            - In
-                                            - NotIn
-                                            - Exists
-                                            - DoesNotExist
-                                            - Gt
-                                            - Lt
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          - Gt
+                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -591,10 +1639,10 @@ spec:
                                                 operators are In, NotIn, Exists and
                                                 DoesNotExist.
                                               enum:
-                                                - In
-                                                - NotIn
-                                                - Exists
-                                                - DoesNotExist
+                                              - In
+                                              - NotIn
+                                              - Exists
+                                              - DoesNotExist
                                               type: string
                                             values:
                                               description: values is an array of string
@@ -694,10 +1742,10 @@ spec:
                                             relationship to a set of values. Valid
                                             operators are In, NotIn, Exists and DoesNotExist.
                                           enum:
-                                            - In
-                                            - NotIn
-                                            - Exists
-                                            - DoesNotExist
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
                                           type: string
                                         values:
                                           description: values is an array of string
@@ -797,10 +1845,10 @@ spec:
                                                 operators are In, NotIn, Exists and
                                                 DoesNotExist.
                                               enum:
-                                                - In
-                                                - NotIn
-                                                - Exists
-                                                - DoesNotExist
+                                              - In
+                                              - NotIn
+                                              - Exists
+                                              - DoesNotExist
                                               type: string
                                             values:
                                               description: values is an array of string
@@ -900,10 +1948,10 @@ spec:
                                             relationship to a set of values. Valid
                                             operators are In, NotIn, Exists and DoesNotExist.
                                           enum:
-                                            - In
-                                            - NotIn
-                                            - Exists
-                                            - DoesNotExist
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
                                           type: string
                                         values:
                                           description: values is an array of string
@@ -1307,9 +2355,9 @@ spec:
                     description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults
                       to "TCP".
                     enum:
-                      - UDP
-                      - TCP
-                      - SCTP
+                    - UDP
+                    - TCP
+                    - SCTP
                     type: string
                 required:
                 - containerPort
@@ -1328,9 +2376,1199 @@ spec:
                 be using It can take either Ephemeral or persistence Default StorageType
                 is Persistence storage
               enum:
-                  - ephemeral
-                  - persistence
+              - ephemeral
+              - persistence
               type: string
+            volumes:
+              description: Volumes defines to support customized volumes
+              items:
+                description: Volume represents a named volume in a pod that may be
+                  accessed by any container in the pod.
+                properties:
+                  awsElasticBlockStore:
+                    description: 'AWSElasticBlockStore represents an AWS Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty).'
+                        format: int32
+                        type: integer
+                      readOnly:
+                        description: 'Specify "true" to force and set the ReadOnly
+                          property in VolumeMounts to "true". If omitted, the default
+                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: boolean
+                      volumeID:
+                        description: 'Unique ID of the persistent disk resource in
+                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  azureDisk:
+                    description: AzureDisk represents an Azure Data Disk mount on
+                      the host and bind mount to the pod.
+                    properties:
+                      cachingMode:
+                        description: 'Host Caching mode: None, Read Only, Read Write.'
+                        type: string
+                      diskName:
+                        description: The Name of the data disk in the blob storage
+                        type: string
+                      diskURI:
+                        description: The URI the data disk in the blob storage
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      kind:
+                        description: 'Expected values Shared: multiple blob disks
+                          per storage account  Dedicated: single blob disk per storage
+                          account  Managed: azure managed data disk (only in managed
+                          availability set). defaults to shared'
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                    required:
+                    - diskName
+                    - diskURI
+                    type: object
+                  azureFile:
+                    description: AzureFile represents an Azure File Service mount
+                      on the host and bind mount to the pod.
+                    properties:
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretName:
+                        description: the name of secret that contains Azure Storage
+                          Account Name and Key
+                        type: string
+                      shareName:
+                        description: Share Name
+                        type: string
+                    required:
+                    - secretName
+                    - shareName
+                    type: object
+                  cephfs:
+                    description: CephFS represents a Ceph FS mount on the host that
+                      shares a pod's lifetime
+                    properties:
+                      monitors:
+                        description: 'Required: Monitors is a collection of Ceph monitors
+                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        items:
+                          type: string
+                        type: array
+                      path:
+                        description: 'Optional: Used as the mounted root, rather than
+                          the full Ceph tree, default is /'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: boolean
+                      secretFile:
+                        description: 'Optional: SecretFile is the path to key ring
+                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the authentication
+                          secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      user:
+                        description: 'Optional: User is the rados user name, default
+                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - monitors
+                    type: object
+                  cinder:
+                    description: 'Cinder represents a cinder volume attached and mounted
+                      on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Examples: "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: points to a secret object containing
+                          parameters used to connect to OpenStack.'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      volumeID:
+                        description: 'volume id used to identify the volume in cinder.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  configMap:
+                    description: ConfigMap represents a configMap that should populate
+                      this volume
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced ConfigMap will be projected into
+                          the volume as a file whose name is the key and content is
+                          the value. If specified, the listed keys will be projected
+                          into the specified paths, and unlisted keys will not be
+                          present. If a key is specified which is not present in the
+                          ConfigMap, the volume setup will error unless it is marked
+                          optional. Paths must be relative and may not contain the
+                          '..' path or start with '..'.
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          type: object
+                        type: array
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the ConfigMap or its keys must
+                          be defined
+                        type: boolean
+                    type: object
+                  csi:
+                    description: CSI (Container Storage Interface) represents storage
+                      that is handled by an external CSI driver (Alpha feature).
+                    properties:
+                      driver:
+                        description: Driver is the name of the CSI driver that handles
+                          this volume. Consult with your admin for the correct name
+                          as registered in the cluster.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Ex. "ext4", "xfs",
+                          "ntfs". If not provided, the empty value is passed to the
+                          associated CSI driver which will determine the default filesystem
+                          to apply.
+                        type: string
+                      nodePublishSecretRef:
+                        description: NodePublishSecretRef is a reference to the secret
+                          object containing sensitive information to pass to the CSI
+                          driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
+                          calls. This field is optional, and  may be empty if no secret
+                          is required. If the secret object contains more than one
+                          secret, all secret references are passed.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      readOnly:
+                        description: Specifies a read-only configuration for the volume.
+                          Defaults to false (read/write).
+                        type: boolean
+                      volumeAttributes:
+                        additionalProperties:
+                          type: string
+                        description: VolumeAttributes stores driver-specific properties
+                          that are passed to the CSI driver. Consult your driver's
+                          documentation for supported values.
+                        type: object
+                    required:
+                    - driver
+                    type: object
+                  downwardAPI:
+                    description: DownwardAPI represents downward API about the pod
+                      that should populate this volume
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: Items is a list of downward API volume file
+                        items:
+                          description: DownwardAPIVolumeFile represents information
+                            to create the file containing the pod field
+                          properties:
+                            fieldRef:
+                              description: 'Required: Selects a field of the pod:
+                                only annotations, labels, name and namespace are supported.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: 'Required: Path is  the relative path name
+                                of the file to be created. Must not be absolute or
+                                contain the ''..'' path. Must be utf-8 encoded. The
+                                first item of the relative path must not start with
+                                ''..'''
+                              type: string
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                requests.cpu and requests.memory) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                          required:
+                          - path
+                          type: object
+                        type: array
+                    type: object
+                  emptyDir:
+                    description: 'EmptyDir represents a temporary directory that shares
+                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                    properties:
+                      medium:
+                        description: 'What type of storage medium should back this
+                          directory. The default is "" which means to use the node''s
+                          default medium. Must be an empty string (default) or Memory.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: string
+                      sizeLimit:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'Total amount of local storage required for this
+                          EmptyDir volume. The size limit is also applicable for memory
+                          medium. The maximum usage on memory medium EmptyDir would
+                          be the minimum value between the SizeLimit specified here
+                          and the sum of memory limits of all containers in a pod.
+                          The default is nil which means that the limit is undefined.
+                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  fc:
+                    description: FC represents a Fibre Channel resource that is attached
+                      to a kubelet's host machine and then exposed to the pod.
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      lun:
+                        description: 'Optional: FC target lun number'
+                        format: int32
+                        type: integer
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      targetWWNs:
+                        description: 'Optional: FC target worldwide names (WWNs)'
+                        items:
+                          type: string
+                        type: array
+                      wwids:
+                        description: 'Optional: FC volume world wide identifiers (wwids)
+                          Either wwids or combination of targetWWNs and lun must be
+                          set, but not both simultaneously.'
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  flexVolume:
+                    description: FlexVolume represents a generic volume resource that
+                      is provisioned/attached using an exec based plugin.
+                    properties:
+                      driver:
+                        description: Driver is the name of the driver to use for this
+                          volume.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". The default filesystem depends on FlexVolume
+                          script.
+                        type: string
+                      options:
+                        additionalProperties:
+                          type: string
+                        description: 'Optional: Extra command options if any.'
+                        type: object
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the secret
+                          object containing sensitive information to pass to the plugin
+                          scripts. This may be empty if no secret object is specified.
+                          If the secret object contains more than one secret, all
+                          secrets are passed to the plugin scripts.'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                    required:
+                    - driver
+                    type: object
+                  flocker:
+                    description: Flocker represents a Flocker volume attached to a
+                      kubelet's host machine. This depends on the Flocker control
+                      service being running
+                    properties:
+                      datasetName:
+                        description: Name of the dataset stored as metadata -> name
+                          on the dataset for Flocker should be considered as deprecated
+                        type: string
+                      datasetUUID:
+                        description: UUID of the dataset. This is unique identifier
+                          of a Flocker dataset
+                        type: string
+                    type: object
+                  gcePersistentDisk:
+                    description: 'GCEPersistentDisk represents a GCE Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        format: int32
+                        type: integer
+                      pdName:
+                        description: 'Unique name of the PD resource in GCE. Used
+                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: boolean
+                    required:
+                    - pdName
+                    type: object
+                  gitRepo:
+                    description: 'GitRepo represents a git repository at a particular
+                      revision. DEPRECATED: GitRepo is deprecated. To provision a
+                      container with a git repo, mount an EmptyDir into an InitContainer
+                      that clones the repo using git, then mount the EmptyDir into
+                      the Pod''s container.'
+                    properties:
+                      directory:
+                        description: Target directory name. Must not contain or start
+                          with '..'.  If '.' is supplied, the volume directory will
+                          be the git repository.  Otherwise, if specified, the volume
+                          will contain the git repository in the subdirectory with
+                          the given name.
+                        type: string
+                      repository:
+                        description: Repository URL
+                        type: string
+                      revision:
+                        description: Commit hash for the specified revision.
+                        type: string
+                    required:
+                    - repository
+                    type: object
+                  glusterfs:
+                    description: 'Glusterfs represents a Glusterfs mount on the host
+                      that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                    properties:
+                      endpoints:
+                        description: 'EndpointsName is the endpoint name that details
+                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      path:
+                        description: 'Path is the Glusterfs volume path. More info:
+                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the Glusterfs volume
+                          to be mounted with read-only permissions. Defaults to false.
+                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: boolean
+                    required:
+                    - endpoints
+                    - path
+                    type: object
+                  hostPath:
+                    description: 'HostPath represents a pre-existing file or directory
+                      on the host machine that is directly exposed to the container.
+                      This is generally used for system agents or other privileged
+                      things that are allowed to see the host machine. Most containers
+                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                      --- TODO(jonesdl) We need to restrict who can use host directory
+                      mounts and who can/can not mount host directories as read/write.'
+                    properties:
+                      path:
+                        description: 'Path of the directory on the host. If the path
+                          is a symlink, it will follow the link to the real path.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                      type:
+                        description: 'Type for HostPath Volume Defaults to "" More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  iscsi:
+                    description: 'ISCSI represents an ISCSI Disk resource that is
+                      attached to a kubelet''s host machine and then exposed to the
+                      pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                    properties:
+                      chapAuthDiscovery:
+                        description: whether support iSCSI Discovery CHAP authentication
+                        type: boolean
+                      chapAuthSession:
+                        description: whether support iSCSI Session CHAP authentication
+                        type: boolean
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      initiatorName:
+                        description: Custom iSCSI Initiator Name. If initiatorName
+                          is specified with iscsiInterface simultaneously, new iSCSI
+                          interface <target portal>:<volume name> will be created
+                          for the connection.
+                        type: string
+                      iqn:
+                        description: Target iSCSI Qualified Name.
+                        type: string
+                      iscsiInterface:
+                        description: iSCSI Interface Name that uses an iSCSI transport.
+                          Defaults to 'default' (tcp).
+                        type: string
+                      lun:
+                        description: iSCSI Target Lun number.
+                        format: int32
+                        type: integer
+                      portals:
+                        description: iSCSI Target Portal List. The portal is either
+                          an IP or ip_addr:port if the port is other than default
+                          (typically TCP ports 860 and 3260).
+                        items:
+                          type: string
+                        type: array
+                      readOnly:
+                        description: ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false.
+                        type: boolean
+                      secretRef:
+                        description: CHAP Secret for iSCSI target and initiator authentication
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      targetPortal:
+                        description: iSCSI Target Portal. The Portal is either an
+                          IP or ip_addr:port if the port is other than default (typically
+                          TCP ports 860 and 3260).
+                        type: string
+                    required:
+                    - iqn
+                    - lun
+                    - targetPortal
+                    type: object
+                  name:
+                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
+                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  nfs:
+                    description: 'NFS represents an NFS mount on the host that shares
+                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    properties:
+                      path:
+                        description: 'Path that is exported by the NFS server. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the NFS export to be
+                          mounted with read-only permissions. Defaults to false. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: boolean
+                      server:
+                        description: 'Server is the hostname or IP address of the
+                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                    required:
+                    - path
+                    - server
+                    type: object
+                  persistentVolumeClaim:
+                    description: 'PersistentVolumeClaimVolumeSource represents a reference
+                      to a PersistentVolumeClaim in the same namespace. More info:
+                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                    properties:
+                      claimName:
+                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                          in the same namespace as the pod using this volume. More
+                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: string
+                      readOnly:
+                        description: Will force the ReadOnly setting in VolumeMounts.
+                          Default false.
+                        type: boolean
+                    required:
+                    - claimName
+                    type: object
+                  photonPersistentDisk:
+                    description: PhotonPersistentDisk represents a PhotonController
+                      persistent disk attached and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      pdID:
+                        description: ID that identifies Photon Controller persistent
+                          disk
+                        type: string
+                    required:
+                    - pdID
+                    type: object
+                  portworxVolume:
+                    description: PortworxVolume represents a portworx volume attached
+                      and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: FSType represents the filesystem type to mount
+                          Must be a filesystem type supported by the host operating
+                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                          if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      volumeID:
+                        description: VolumeID uniquely identifies a Portworx volume
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  projected:
+                    description: Items for all in one resources secrets, configmaps,
+                      and downward API
+                    properties:
+                      defaultMode:
+                        description: Mode bits to use on created files by default.
+                          Must be a value between 0 and 0777. Directories within the
+                          path are not affected by this setting. This might be in
+                          conflict with other options that affect the file mode, like
+                          fsGroup, and the result can be other mode bits set.
+                        format: int32
+                        type: integer
+                      sources:
+                        description: list of volume projections
+                        items:
+                          description: Projection that may be projected along with
+                            other supported volume types
+                          properties:
+                            configMap:
+                              description: information about the configMap data to
+                                project
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    keys must be defined
+                                  type: boolean
+                              type: object
+                            downwardAPI:
+                              description: information about the downwardAPI data
+                                to project
+                              properties:
+                                items:
+                                  description: Items is a list of DownwardAPIVolume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            secret:
+                              description: information about the secret data to project
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced Secret will
+                                    be projected into the volume as a file whose name
+                                    is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              type: object
+                            serviceAccountToken:
+                              description: information about the serviceAccountToken
+                                data to project
+                              properties:
+                                audience:
+                                  description: Audience is the intended audience of
+                                    the token. A recipient of a token must identify
+                                    itself with an identifier specified in the audience
+                                    of the token, and otherwise should reject the
+                                    token. The audience defaults to the identifier
+                                    of the apiserver.
+                                  type: string
+                                expirationSeconds:
+                                  description: ExpirationSeconds is the requested
+                                    duration of validity of the service account token.
+                                    As the token approaches expiration, the kubelet
+                                    volume plugin will proactively rotate the service
+                                    account token. The kubelet will start trying to
+                                    rotate the token if the token is older than 80
+                                    percent of its time to live or if the token is
+                                    older than 24 hours.Defaults to 1 hour and must
+                                    be at least 10 minutes.
+                                  format: int64
+                                  type: integer
+                                path:
+                                  description: Path is the path relative to the mount
+                                    point of the file to project the token into.
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                          type: object
+                        type: array
+                    required:
+                    - sources
+                    type: object
+                  quobyte:
+                    description: Quobyte represents a Quobyte mount on the host that
+                      shares a pod's lifetime
+                    properties:
+                      group:
+                        description: Group to map volume access to Default is no group
+                        type: string
+                      readOnly:
+                        description: ReadOnly here will force the Quobyte volume to
+                          be mounted with read-only permissions. Defaults to false.
+                        type: boolean
+                      registry:
+                        description: Registry represents a single or multiple Quobyte
+                          Registry services specified as a string as host:port pair
+                          (multiple entries are separated with commas) which acts
+                          as the central registry for volumes
+                        type: string
+                      tenant:
+                        description: Tenant owning the given Quobyte volume in the
+                          Backend Used with dynamically provisioned Quobyte volumes,
+                          value is set by the plugin
+                        type: string
+                      user:
+                        description: User to map volume access to Defaults to serivceaccount
+                          user
+                        type: string
+                      volume:
+                        description: Volume is a string that references an already
+                          created Quobyte volume by name.
+                        type: string
+                    required:
+                    - registry
+                    - volume
+                    type: object
+                  rbd:
+                    description: 'RBD represents a Rados Block Device mount on the
+                      host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      image:
+                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      keyring:
+                        description: 'Keyring is the path to key ring for RBDUser.
+                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      monitors:
+                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        items:
+                          type: string
+                        type: array
+                      pool:
+                        description: 'The rados pool name. Default is rbd. More info:
+                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: boolean
+                      secretRef:
+                        description: 'SecretRef is name of the authentication secret
+                          for RBDUser. If provided overrides keyring. Default is nil.
+                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      user:
+                        description: 'The rados user name. Default is admin. More
+                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - image
+                    - monitors
+                    type: object
+                  scaleIO:
+                    description: ScaleIO represents a ScaleIO persistent volume attached
+                      and mounted on Kubernetes nodes.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Default is "xfs".
+                        type: string
+                      gateway:
+                        description: The host address of the ScaleIO API Gateway.
+                        type: string
+                      protectionDomain:
+                        description: The name of the ScaleIO Protection Domain for
+                          the configured storage.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef references to the secret for ScaleIO
+                          user and other sensitive information. If this is not provided,
+                          Login operation will fail.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      sslEnabled:
+                        description: Flag to enable/disable SSL communication with
+                          Gateway, default false
+                        type: boolean
+                      storageMode:
+                        description: Indicates whether the storage for a volume should
+                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                        type: string
+                      storagePool:
+                        description: The ScaleIO Storage Pool associated with the
+                          protection domain.
+                        type: string
+                      system:
+                        description: The name of the storage system as configured
+                          in ScaleIO.
+                        type: string
+                      volumeName:
+                        description: The name of a volume already created in the ScaleIO
+                          system that is associated with this volume source.
+                        type: string
+                    required:
+                    - gateway
+                    - secretRef
+                    - system
+                    type: object
+                  secret:
+                    description: 'Secret represents a secret that should populate
+                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced Secret will be projected into the
+                          volume as a file whose name is the key and content is the
+                          value. If specified, the listed keys will be projected into
+                          the specified paths, and unlisted keys will not be present.
+                          If a key is specified which is not present in the Secret,
+                          the volume setup will error unless it is marked optional.
+                          Paths must be relative and may not contain the '..' path
+                          or start with '..'.
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          type: object
+                        type: array
+                      optional:
+                        description: Specify whether the Secret or its keys must be
+                          defined
+                        type: boolean
+                      secretName:
+                        description: 'Name of the secret in the pod''s namespace to
+                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: string
+                    type: object
+                  storageos:
+                    description: StorageOS represents a StorageOS volume attached
+                      and mounted on Kubernetes nodes.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef specifies the secret to use for obtaining
+                          the StorageOS API credentials.  If not specified, default
+                          values will be attempted.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      volumeName:
+                        description: VolumeName is the human-readable name of the
+                          StorageOS volume.  Volume names are only unique within a
+                          namespace.
+                        type: string
+                      volumeNamespace:
+                        description: VolumeNamespace specifies the scope of the volume
+                          within StorageOS.  If no namespace is specified then the
+                          Pod's namespace will be used.  This allows the Kubernetes
+                          name scoping to be mirrored within StorageOS for tighter
+                          integration. Set VolumeName to any name to override the
+                          default behaviour. Set to "default" if you are not using
+                          namespaces within StorageOS. Namespaces that do not pre-exist
+                          within StorageOS will be created.
+                        type: string
+                    type: object
+                  vsphereVolume:
+                    description: VsphereVolume represents a vSphere volume attached
+                      and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      storagePolicyID:
+                        description: Storage Policy Based Management (SPBM) profile
+                          ID associated with the StoragePolicyName.
+                        type: string
+                      storagePolicyName:
+                        description: Storage Policy Based Management (SPBM) profile
+                          name.
+                        type: string
+                      volumePath:
+                        description: Path that identifies vSphere volume vmdk
+                        type: string
+                    required:
+                    - volumePath
+                    type: object
+                required:
+                - name
+                type: object
+              type: array
           type: object
         status:
           description: ZookeeperClusterStatus defines the observed state of ZookeeperCluster
@@ -1407,10 +3645,4 @@ spec:
   - name: v1beta1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -1,5 +1,4 @@
-
----
+{{- if .Values.crd.create }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -16,6 +15,34 @@ spec:
     shortNames:
     - zk
     singular: zookeepercluster
+  additionalPrinterColumns:
+  - name: Replicas
+    type: integer
+    description: The number of ZooKeeper servers in the ensemble
+    JSONPath: .spec.replicas
+  - name: Ready Replicas
+    type: integer
+    description: The number of ZooKeeper servers in the ensemble that are in a Ready state
+    JSONPath: .status.readyReplicas
+  - name: Version
+    type: string
+    description: The current Zookeeper version
+    JSONPath: .status.currentVersion
+  - name: Desired Version
+    type: string
+    description: The desired Zookeeper version
+    JSONPath: .spec.image.tag
+  - name: Internal Endpoint
+    type: string
+    description: Client endpoint internal to cluster network
+    JSONPath: .status.internalClientEndpoint
+  - name: External Endpoint
+    type: string
+    description: Client endpoint external to cluster network via LoadBalancer
+    JSONPath: .status.externalClientEndpoint
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
   scope: Namespaced
   subresources:
     status: {}
@@ -1386,3 +1413,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -23,6 +23,10 @@ serviceAccount:
   ## Optionally specify an array of imagePullSecrets. Will override the global parameter if set
   # imagePullSecrets:
 
+## Whether to create the CRD.
+crd:
+  create: true
+
 ## Specifies which namespace(s) the Operator should watch over.
 ## Default: An empty string means all namespaces.
 ## Multiple namespaces can be configured using a comma separated list of namespaces
@@ -47,4 +51,3 @@ hooks:
   image:
     repository: lachlanevenson/k8s-kubectl
     tag: v1.16.10
-

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -37,6 +37,11 @@ resources: {}
   #   cpu: 1
   #   memory: 128Mi
 
+# Scheduling constraints
+nodeSelector: {}
+affinity: {}
+tolerations: []
+
 hooks:
   backoffLimit: 10
   image:

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -66,3 +66,5 @@ The following table lists the configurable parameters of the Zookeeper chart and
 | `persistence.volumeSize` | Size of the volume requested for persistent volumes | `20Gi` |
 | `ephemeral.emptydirvolumesource.medium` |  What type of storage medium should back the directory. | `""` |
 | `ephemeral.emptydirvolumesource.sizeLimit` | Total amount of local storage required for the EmptyDir volume. | |
+| `containers` | Application containers run with the zookeeper pod | `[]` |
+| `volumes` | Named volumes that may be accessed by any container in the pod | `[]` |

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -9,7 +9,7 @@ This chart creates a Zookeeper cluster in [Kubernetes](http://kubernetes.io) usi
 ## Prerequisites
 
   - Kubernetes 1.15+ with Beta APIs
-  - Helm 3+
+  - Helm 3.2.1+
   - Zookeeper Operator. You can install it using its own [Helm chart](https://github.com/pravega/zookeeper-operator/tree/master/charts/zookeeper-operator)
 
 ## Installing the Chart
@@ -17,14 +17,25 @@ This chart creates a Zookeeper cluster in [Kubernetes](http://kubernetes.io) usi
 To install the chart with the release name `my-release`:
 
 ```
-$ helm install my-release zookeeper
+$ helm repo add pravega https://charts.pravega.io
+$ helm repo update
+$ helm install my-release pravega/zookeeper --version=`version`
 ```
+Note: `version` can be any stable release version for zookeeper from 0.2.8 onwards.
 
 The command deploys zookeeper on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
+## Upgrading the Chart
+
+To upgrade the zookeeper cluster `my-release` from a version x to y:
+```
+$ helm upgrade my-release pravega/zookeeper --version=y --set image.tag=y --reuse-values --timeout 600s
+```
+Note: By specifying the `--reuse-values` option, the values of all parameters are retained across upgrades. However if some values need to be modified during the upgrade, the `--set` flag can be used to specify the new values of these parameters. Also, by skipping the `reuse-values` flag, the values of all parameters are reset to their default values specified in the charts published for version `y`
+
 ## Uninstalling the Chart
 
-To uninstall/delete the `my-release` deployment:
+To uninstall/delete the zookeeper cluster `my-release`:
 
 ```
 $ helm uninstall my-release

--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -14,7 +14,7 @@ spec:
   {{- if .Values.domainName }}
   domainName: {{ .Values.domainName }}
   {{- end }}
-  kubernetesClusterDomain: {{ .Values.kubernetesClusterDomain }}
+  kubernetesClusterDomain: {{ default "cluster.local" .Values.kubernetesClusterDomain }}
   labels:
 {{ toYaml .Values.labels | indent 4 }}
   ports:
@@ -46,8 +46,8 @@ spec:
     syncLimit: {{ .Values.config.syncLimit }}
     quorumListenOnAllIPs: {{ .Values.config.quorumListenOnAllIPs }}
   {{- end }}
-  storageType: {{ .Values.storageType }}
-  {{- if eq .Values.storageType "ephemeral" }}
+  storageType: {{ default "persistence" .Values.storageType }}
+  {{- if eq (default .Values.storageType "persistence") "ephemeral" }}
   ephemeral:
     {{- if .Values.ephemeral.emptydirvolumesource }}
     emptydirvolumesource:

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -51,3 +51,6 @@ hooks:
     repository: lachlanevenson/k8s-kubectl
     tag: v1.16.10
   backoffLimit: 10
+
+containers: []
+volumes: []

--- a/deploy/all_ns/operator.yaml
+++ b/deploy/all_ns/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: zookeeper-operator
           # Replace this with the built image name
-          image: pravega/zookeeper-operator:latest
+          image: pravega/zookeeper-operator:0.2.8
           ports:
           - containerPort: 60000
             name: metrics

--- a/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -16,6 +14,34 @@ spec:
     shortNames:
     - zk
     singular: zookeepercluster
+  additionalPrinterColumns:
+  - name: Replicas
+    type: integer
+    description: The number of ZooKeeper servers in the ensemble
+    JSONPath: .spec.replicas
+  - name: Ready Replicas
+    type: integer
+    description: The number of ZooKeeper servers in the ensemble that are in a Ready state
+    JSONPath: .status.readyReplicas
+  - name: Version
+    type: string
+    description: The current Zookeeper version
+    JSONPath: .status.currentVersion
+  - name: Desired Version
+    type: string
+    description: The desired Zookeeper version
+    JSONPath: .spec.image.tag
+  - name: Internal Endpoint
+    type: string
+    description: Client endpoint internal to cluster network
+    JSONPath: .status.internalClientEndpoint
+  - name: External Endpoint
+    type: string
+    description: Client endpoint external to cluster network via LoadBalancer
+    JSONPath: .status.externalClientEndpoint
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp  
   scope: Namespaced
   subresources:
     status: {}

--- a/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -1,11 +1,37 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
-  creationTimestamp: null
   name: zookeeperclusters.zookeeper.pravega.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.replicas
+    description: The number of ZooKeeper servers in the ensemble
+    name: Replicas
+    type: integer
+  - JSONPath: .status.readyReplicas
+    description: The number of ZooKeeper servers in the ensemble that are in a Ready
+      state
+    name: Ready Replicas
+    type: integer
+  - JSONPath: .status.currentVersion
+    description: The current Zookeeper version
+    name: Version
+    type: string
+  - JSONPath: .spec.image.tag
+    description: The desired Zookeeper version
+    name: Desired Version
+    type: string
+  - JSONPath: .status.internalClientEndpoint
+    description: Client endpoint internal to cluster network
+    name: Internal Endpoint
+    type: string
+  - JSONPath: .status.externalClientEndpoint
+    description: Client endpoint external to cluster network via LoadBalancer
+    name: External Endpoint
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: zookeeper.pravega.io
   names:
     kind: ZookeeperCluster
@@ -14,34 +40,6 @@ spec:
     shortNames:
     - zk
     singular: zookeepercluster
-  additionalPrinterColumns:
-  - name: Replicas
-    type: integer
-    description: The number of ZooKeeper servers in the ensemble
-    JSONPath: .spec.replicas
-  - name: Ready Replicas
-    type: integer
-    description: The number of ZooKeeper servers in the ensemble that are in a Ready state
-    JSONPath: .status.readyReplicas
-  - name: Version
-    type: string
-    description: The current Zookeeper version
-    JSONPath: .status.currentVersion
-  - name: Desired Version
-    type: string
-    description: The desired Zookeeper version
-    JSONPath: .spec.image.tag
-  - name: Internal Endpoint
-    type: string
-    description: Client endpoint internal to cluster network
-    JSONPath: .status.internalClientEndpoint
-  - name: External Endpoint
-    type: string
-    description: Client endpoint external to cluster network via LoadBalancer
-    JSONPath: .status.externalClientEndpoint
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp  
   scope: Namespaced
   subresources:
     status: {}
@@ -1185,9 +1183,9 @@ spec:
                   description: PullPolicy describes a policy for if/when to pull a
                     container image
                   enum:
-                    - Always
-                    - Never
-                    - IfNotPresent
+                  - Always
+                  - Never
+                  - IfNotPresent
                   type: string
                 repository:
                   type: string
@@ -1214,8 +1212,8 @@ spec:
                     by the operator when zookeeper cluster is deleted. The default
                     value is Retain.
                   enum:
-                    - Delete
-                    - Retain
+                  - Delete
+                  - Retain
                   type: string
                 spec:
                   description: PersistentVolumeClaimSpec is the spec to describe PVC
@@ -1227,9 +1225,9 @@ spec:
                         the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                       items:
                         enum:
-                          - ReadWriteOnce
-                          - ReadOnlyMany
-                          - ReadWriteMany
+                        - ReadWriteOnce
+                        - ReadOnlyMany
+                        - ReadWriteMany
                         type: string
                       type: array
                     dataSource:
@@ -1307,10 +1305,10 @@ spec:
                                   to a set of values. Valid operators are In, NotIn,
                                   Exists and DoesNotExist.
                                 enum:
-                                    - In
-                                    - NotIn
-                                    - Exists
-                                    - DoesNotExist
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
                                 type: string
                               values:
                                 description: values is an array of string values.
@@ -1402,12 +1400,12 @@ spec:
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
                                           enum:
-                                            - In
-                                            - NotIn
-                                            - Exists
-                                            - DoesNotExist
-                                            - Gt
-                                            - Lt
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          - Gt
+                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -1445,12 +1443,12 @@ spec:
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
                                           enum:
-                                            - In
-                                            - NotIn
-                                            - Exists
-                                            - DoesNotExist
-                                            - Gt
-                                            - Lt
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          - Gt
+                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -1517,12 +1515,12 @@ spec:
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
                                           enum:
-                                            - In
-                                            - NotIn
-                                            - Exists
-                                            - DoesNotExist
-                                            - Gt
-                                            - Lt
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          - Gt
+                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -1560,12 +1558,12 @@ spec:
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
                                           enum:
-                                            - In
-                                            - NotIn
-                                            - Exists
-                                            - DoesNotExist
-                                            - Gt
-                                            - Lt
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          - Gt
+                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -1640,10 +1638,10 @@ spec:
                                                 operators are In, NotIn, Exists and
                                                 DoesNotExist.
                                               enum:
-                                                - In
-                                                - NotIn
-                                                - Exists
-                                                - DoesNotExist
+                                              - In
+                                              - NotIn
+                                              - Exists
+                                              - DoesNotExist
                                               type: string
                                             values:
                                               description: values is an array of string
@@ -1743,10 +1741,10 @@ spec:
                                             relationship to a set of values. Valid
                                             operators are In, NotIn, Exists and DoesNotExist.
                                           enum:
-                                            - In
-                                            - NotIn
-                                            - Exists
-                                            - DoesNotExist
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
                                           type: string
                                         values:
                                           description: values is an array of string
@@ -1846,10 +1844,10 @@ spec:
                                                 operators are In, NotIn, Exists and
                                                 DoesNotExist.
                                               enum:
-                                                - In
-                                                - NotIn
-                                                - Exists
-                                                - DoesNotExist
+                                              - In
+                                              - NotIn
+                                              - Exists
+                                              - DoesNotExist
                                               type: string
                                             values:
                                               description: values is an array of string
@@ -1949,10 +1947,10 @@ spec:
                                             relationship to a set of values. Valid
                                             operators are In, NotIn, Exists and DoesNotExist.
                                           enum:
-                                            - In
-                                            - NotIn
-                                            - Exists
-                                            - DoesNotExist
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
                                           type: string
                                         values:
                                           description: values is an array of string
@@ -2356,9 +2354,9 @@ spec:
                     description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults
                       to "TCP".
                     enum:
-                      - UDP
-                      - TCP
-                      - SCTP
+                    - UDP
+                    - TCP
+                    - SCTP
                     type: string
                 required:
                 - containerPort
@@ -2377,8 +2375,8 @@ spec:
                 be using It can take either Ephemeral or persistence Default StorageType
                 is Persistence storage
               enum:
-                  - ephemeral
-                  - persistence
+              - ephemeral
+              - persistence
               type: string
             volumes:
               description: Volumes defines to support customized volumes
@@ -3646,9 +3644,3 @@ spec:
   - name: v1beta1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -67,6 +67,1056 @@ spec:
                     \n The default value is 2000."
                   type: integer
               type: object
+            containers:
+              description: Containers defines to support multi containers
+              items:
+                description: A single application container that you want to run within
+                  a pod.
+                properties:
+                  args:
+                    description: 'Arguments to the entrypoint. The docker image''s
+                      CMD is used if this is not provided. Variable references $(VAR_NAME)
+                      are expanded using the container''s environment. If a variable
+                      cannot be resolved, the reference in the input string will be
+                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                      regardless of whether the variable exists or not. Cannot be
+                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: 'Entrypoint array. Not executed within a shell. The
+                      docker image''s ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container''s
+                      environment. If a variable cannot be resolved, the reference
+                      in the input string will be unchanged. The $(VAR_NAME) syntax
+                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                      will never be expanded, regardless of whether the variable exists
+                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, metadata.labels, metadata.annotations,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP,
+                                status.podIP, status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: List of sources to populate environment variables
+                      in the container. The keys defined within a source must be a
+                      C_IDENTIFIER. All invalid keys will be reported as an event
+                      when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take
+                      precedence. Values defined by an Env with a duplicate key will
+                      take precedence. Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
+                  image:
+                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management
+                      to default or override container images in workload controllers
+                      like Deployments and StatefulSets.'
+                    type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent
+                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                  lifecycle:
+                    description: Actions that the management system should take in
+                      response to container lifecycle events. Cannot be updated.
+                    properties:
+                      postStart:
+                        description: 'PostStart is called immediately after a container
+                          is created. If the handler fails, the container is terminated
+                          and restarted according to its restart policy. Other management
+                          of the container blocks until the hook completes. More info:
+                          https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                        properties:
+                          exec:
+                            description: One and only one of the following should
+                              be specified. Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      preStop:
+                        description: 'PreStop is called immediately before a container
+                          is terminated due to an API request or management event
+                          such as liveness/startup probe failure, preemption, resource
+                          contention, etc. The handler is not called if the container
+                          crashes or exits. The reason for termination is passed to
+                          the handler. The Pod''s termination grace period countdown
+                          begins before the PreStop hooked is executed. Regardless
+                          of the outcome of the handler, the container will eventually
+                          terminate within the Pod''s termination grace period. Other
+                          management of the container blocks until the hook completes
+                          or until the termination grace period is reached. More info:
+                          https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                        properties:
+                          exec:
+                            description: One and only one of the following should
+                              be specified. Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                    type: object
+                  livenessProbe:
+                    description: 'Periodic probe of container liveness. Container
+                      will be restarted if the probe fails. Cannot be updated. More
+                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    properties:
+                      exec:
+                        description: One and only one of the following should be specified.
+                          Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness and startup. Minimum value is
+                          1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: 'TCPSocket specifies an action involving a TCP
+                          port. TCP hooks not yet supported TODO: implement a realistic
+                          TCP lifecycle hook'
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  name:
+                    description: Name of the container specified as a DNS_LABEL. Each
+                      container in a pod must have a unique name (DNS_LABEL). Cannot
+                      be updated.
+                    type: string
+                  ports:
+                    description: List of ports to expose from the container. Exposing
+                      a port here gives the system additional information about the
+                      network connections a container uses, but is primarily informational.
+                      Not specifying a port here DOES NOT prevent that port from being
+                      exposed. Any port which is listening on the default "0.0.0.0"
+                      address inside a container will be accessible from the network.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: Number of port to expose on the host. If specified,
+                            this must be a valid port number, 0 < x < 65536. If HostNetwork
+                            is specified, this must match ContainerPort. Most containers
+                            do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: If specified, this must be an IANA_SVC_NAME
+                            and unique within the pod. Each named port in a pod must
+                            have a unique name. Name for the port that can be referred
+                            to by services.
+                          type: string
+                        protocol:
+                          description: Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerPort
+                    - protocol
+                    x-kubernetes-list-type: map
+                  readinessProbe:
+                    description: 'Periodic probe of container service readiness. Container
+                      will be removed from service endpoints if the probe fails. Cannot
+                      be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    properties:
+                      exec:
+                        description: One and only one of the following should be specified.
+                          Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness and startup. Minimum value is
+                          1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: 'TCPSocket specifies an action involving a TCP
+                          port. TCP hooks not yet supported TODO: implement a realistic
+                          TCP lifecycle hook'
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  resources:
+                    description: 'Compute Resources required by this container. Cannot
+                      be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  securityContext:
+                    description: 'Security options the pod should run with. More info:
+                      https://kubernetes.io/docs/concepts/policy/security-context/
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. This field is beta-level and may be
+                              disabled with the WindowsRunAsUserName feature flag.
+                            type: string
+                        type: object
+                    type: object
+                  startupProbe:
+                    description: 'StartupProbe indicates that the Pod has successfully
+                      initialized. If specified, no other probes are executed until
+                      this completes successfully. If this probe fails, the Pod will
+                      be restarted, just as if the livenessProbe failed. This can
+                      be used to provide different probe parameters at the beginning
+                      of a Pod''s lifecycle, when it might take a long time to load
+                      data or warm a cache, than during steady-state operation. This
+                      cannot be updated. This is an alpha feature enabled by the StartupProbe
+                      feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    properties:
+                      exec:
+                        description: One and only one of the following should be specified.
+                          Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness and startup. Minimum value is
+                          1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: 'TCPSocket specifies an action involving a TCP
+                          port. TCP hooks not yet supported TODO: implement a realistic
+                          TCP lifecycle hook'
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  stdin:
+                    description: Whether this container should allocate a buffer for
+                      stdin in the container runtime. If this is not set, reads from
+                      stdin in the container will always result in EOF. Default is
+                      false.
+                    type: boolean
+                  stdinOnce:
+                    description: Whether the container runtime should close the stdin
+                      channel after it has been opened by a single attach. When stdin
+                      is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container
+                      start, is empty until the first client attaches to stdin, and
+                      then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container
+                      is restarted. If this flag is false, a container processes that
+                      reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s
+                      termination message will be written is mounted into the container''s
+                      filesystem. Message written is intended to be brief final status,
+                      such as an assertion failure message. Will be truncated by the
+                      node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                      Cannot be updated.'
+                    type: string
+                  terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated.
+                      File will use the contents of terminationMessagePath to populate
+                      the container status message on both success and failure. FallbackToLogsOnError
+                      will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever
+                      is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                  tty:
+                    description: Whether this container should allocate a TTY for
+                      itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container. This is a beta feature.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - devicePath
+                      - name
+                      type: object
+                    type: array
+                  volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            around. When not set, MountPropagationNone is used. This
+                            field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted. Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: Expanded path within the volume from which
+                            the container's volume should be mounted. Behaves similarly
+                            to SubPath but environment variable references $(VAR_NAME)
+                            are expanded using the container's environment. Defaults
+                            to "" (volume's root). SubPathExpr and SubPath are mutually
+                            exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                  workingDir:
+                    description: Container's working directory. If not specified,
+                      the container runtime's default will be used, which might be
+                      configured in the container image. Cannot be updated.
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
             domainName:
               description: External host name appended for dns annotation
               type: string
@@ -1304,6 +2354,1196 @@ spec:
                   - ephemeral
                   - persistence
               type: string
+            volumes:
+              description: Volumes defines to support customized volumes
+              items:
+                description: Volume represents a named volume in a pod that may be
+                  accessed by any container in the pod.
+                properties:
+                  awsElasticBlockStore:
+                    description: 'AWSElasticBlockStore represents an AWS Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty).'
+                        format: int32
+                        type: integer
+                      readOnly:
+                        description: 'Specify "true" to force and set the ReadOnly
+                          property in VolumeMounts to "true". If omitted, the default
+                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: boolean
+                      volumeID:
+                        description: 'Unique ID of the persistent disk resource in
+                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  azureDisk:
+                    description: AzureDisk represents an Azure Data Disk mount on
+                      the host and bind mount to the pod.
+                    properties:
+                      cachingMode:
+                        description: 'Host Caching mode: None, Read Only, Read Write.'
+                        type: string
+                      diskName:
+                        description: The Name of the data disk in the blob storage
+                        type: string
+                      diskURI:
+                        description: The URI the data disk in the blob storage
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      kind:
+                        description: 'Expected values Shared: multiple blob disks
+                          per storage account  Dedicated: single blob disk per storage
+                          account  Managed: azure managed data disk (only in managed
+                          availability set). defaults to shared'
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                    required:
+                    - diskName
+                    - diskURI
+                    type: object
+                  azureFile:
+                    description: AzureFile represents an Azure File Service mount
+                      on the host and bind mount to the pod.
+                    properties:
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretName:
+                        description: the name of secret that contains Azure Storage
+                          Account Name and Key
+                        type: string
+                      shareName:
+                        description: Share Name
+                        type: string
+                    required:
+                    - secretName
+                    - shareName
+                    type: object
+                  cephfs:
+                    description: CephFS represents a Ceph FS mount on the host that
+                      shares a pod's lifetime
+                    properties:
+                      monitors:
+                        description: 'Required: Monitors is a collection of Ceph monitors
+                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        items:
+                          type: string
+                        type: array
+                      path:
+                        description: 'Optional: Used as the mounted root, rather than
+                          the full Ceph tree, default is /'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: boolean
+                      secretFile:
+                        description: 'Optional: SecretFile is the path to key ring
+                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the authentication
+                          secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      user:
+                        description: 'Optional: User is the rados user name, default
+                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - monitors
+                    type: object
+                  cinder:
+                    description: 'Cinder represents a cinder volume attached and mounted
+                      on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Examples: "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: points to a secret object containing
+                          parameters used to connect to OpenStack.'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      volumeID:
+                        description: 'volume id used to identify the volume in cinder.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  configMap:
+                    description: ConfigMap represents a configMap that should populate
+                      this volume
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced ConfigMap will be projected into
+                          the volume as a file whose name is the key and content is
+                          the value. If specified, the listed keys will be projected
+                          into the specified paths, and unlisted keys will not be
+                          present. If a key is specified which is not present in the
+                          ConfigMap, the volume setup will error unless it is marked
+                          optional. Paths must be relative and may not contain the
+                          '..' path or start with '..'.
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          type: object
+                        type: array
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the ConfigMap or its keys must
+                          be defined
+                        type: boolean
+                    type: object
+                  csi:
+                    description: CSI (Container Storage Interface) represents storage
+                      that is handled by an external CSI driver (Alpha feature).
+                    properties:
+                      driver:
+                        description: Driver is the name of the CSI driver that handles
+                          this volume. Consult with your admin for the correct name
+                          as registered in the cluster.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Ex. "ext4", "xfs",
+                          "ntfs". If not provided, the empty value is passed to the
+                          associated CSI driver which will determine the default filesystem
+                          to apply.
+                        type: string
+                      nodePublishSecretRef:
+                        description: NodePublishSecretRef is a reference to the secret
+                          object containing sensitive information to pass to the CSI
+                          driver to complete the CSI NodePublishVolume and NodeUnpublishVolume
+                          calls. This field is optional, and  may be empty if no secret
+                          is required. If the secret object contains more than one
+                          secret, all secret references are passed.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      readOnly:
+                        description: Specifies a read-only configuration for the volume.
+                          Defaults to false (read/write).
+                        type: boolean
+                      volumeAttributes:
+                        additionalProperties:
+                          type: string
+                        description: VolumeAttributes stores driver-specific properties
+                          that are passed to the CSI driver. Consult your driver's
+                          documentation for supported values.
+                        type: object
+                    required:
+                    - driver
+                    type: object
+                  downwardAPI:
+                    description: DownwardAPI represents downward API about the pod
+                      that should populate this volume
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: Items is a list of downward API volume file
+                        items:
+                          description: DownwardAPIVolumeFile represents information
+                            to create the file containing the pod field
+                          properties:
+                            fieldRef:
+                              description: 'Required: Selects a field of the pod:
+                                only annotations, labels, name and namespace are supported.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: 'Required: Path is  the relative path name
+                                of the file to be created. Must not be absolute or
+                                contain the ''..'' path. Must be utf-8 encoded. The
+                                first item of the relative path must not start with
+                                ''..'''
+                              type: string
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                requests.cpu and requests.memory) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                          required:
+                          - path
+                          type: object
+                        type: array
+                    type: object
+                  emptyDir:
+                    description: 'EmptyDir represents a temporary directory that shares
+                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                    properties:
+                      medium:
+                        description: 'What type of storage medium should back this
+                          directory. The default is "" which means to use the node''s
+                          default medium. Must be an empty string (default) or Memory.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: string
+                      sizeLimit:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'Total amount of local storage required for this
+                          EmptyDir volume. The size limit is also applicable for memory
+                          medium. The maximum usage on memory medium EmptyDir would
+                          be the minimum value between the SizeLimit specified here
+                          and the sum of memory limits of all containers in a pod.
+                          The default is nil which means that the limit is undefined.
+                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  fc:
+                    description: FC represents a Fibre Channel resource that is attached
+                      to a kubelet's host machine and then exposed to the pod.
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      lun:
+                        description: 'Optional: FC target lun number'
+                        format: int32
+                        type: integer
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      targetWWNs:
+                        description: 'Optional: FC target worldwide names (WWNs)'
+                        items:
+                          type: string
+                        type: array
+                      wwids:
+                        description: 'Optional: FC volume world wide identifiers (wwids)
+                          Either wwids or combination of targetWWNs and lun must be
+                          set, but not both simultaneously.'
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  flexVolume:
+                    description: FlexVolume represents a generic volume resource that
+                      is provisioned/attached using an exec based plugin.
+                    properties:
+                      driver:
+                        description: Driver is the name of the driver to use for this
+                          volume.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". The default filesystem depends on FlexVolume
+                          script.
+                        type: string
+                      options:
+                        additionalProperties:
+                          type: string
+                        description: 'Optional: Extra command options if any.'
+                        type: object
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the secret
+                          object containing sensitive information to pass to the plugin
+                          scripts. This may be empty if no secret object is specified.
+                          If the secret object contains more than one secret, all
+                          secrets are passed to the plugin scripts.'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                    required:
+                    - driver
+                    type: object
+                  flocker:
+                    description: Flocker represents a Flocker volume attached to a
+                      kubelet's host machine. This depends on the Flocker control
+                      service being running
+                    properties:
+                      datasetName:
+                        description: Name of the dataset stored as metadata -> name
+                          on the dataset for Flocker should be considered as deprecated
+                        type: string
+                      datasetUUID:
+                        description: UUID of the dataset. This is unique identifier
+                          of a Flocker dataset
+                        type: string
+                    type: object
+                  gcePersistentDisk:
+                    description: 'GCEPersistentDisk represents a GCE Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        format: int32
+                        type: integer
+                      pdName:
+                        description: 'Unique name of the PD resource in GCE. Used
+                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: boolean
+                    required:
+                    - pdName
+                    type: object
+                  gitRepo:
+                    description: 'GitRepo represents a git repository at a particular
+                      revision. DEPRECATED: GitRepo is deprecated. To provision a
+                      container with a git repo, mount an EmptyDir into an InitContainer
+                      that clones the repo using git, then mount the EmptyDir into
+                      the Pod''s container.'
+                    properties:
+                      directory:
+                        description: Target directory name. Must not contain or start
+                          with '..'.  If '.' is supplied, the volume directory will
+                          be the git repository.  Otherwise, if specified, the volume
+                          will contain the git repository in the subdirectory with
+                          the given name.
+                        type: string
+                      repository:
+                        description: Repository URL
+                        type: string
+                      revision:
+                        description: Commit hash for the specified revision.
+                        type: string
+                    required:
+                    - repository
+                    type: object
+                  glusterfs:
+                    description: 'Glusterfs represents a Glusterfs mount on the host
+                      that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                    properties:
+                      endpoints:
+                        description: 'EndpointsName is the endpoint name that details
+                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      path:
+                        description: 'Path is the Glusterfs volume path. More info:
+                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the Glusterfs volume
+                          to be mounted with read-only permissions. Defaults to false.
+                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                        type: boolean
+                    required:
+                    - endpoints
+                    - path
+                    type: object
+                  hostPath:
+                    description: 'HostPath represents a pre-existing file or directory
+                      on the host machine that is directly exposed to the container.
+                      This is generally used for system agents or other privileged
+                      things that are allowed to see the host machine. Most containers
+                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                      --- TODO(jonesdl) We need to restrict who can use host directory
+                      mounts and who can/can not mount host directories as read/write.'
+                    properties:
+                      path:
+                        description: 'Path of the directory on the host. If the path
+                          is a symlink, it will follow the link to the real path.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                      type:
+                        description: 'Type for HostPath Volume Defaults to "" More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  iscsi:
+                    description: 'ISCSI represents an ISCSI Disk resource that is
+                      attached to a kubelet''s host machine and then exposed to the
+                      pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                    properties:
+                      chapAuthDiscovery:
+                        description: whether support iSCSI Discovery CHAP authentication
+                        type: boolean
+                      chapAuthSession:
+                        description: whether support iSCSI Session CHAP authentication
+                        type: boolean
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      initiatorName:
+                        description: Custom iSCSI Initiator Name. If initiatorName
+                          is specified with iscsiInterface simultaneously, new iSCSI
+                          interface <target portal>:<volume name> will be created
+                          for the connection.
+                        type: string
+                      iqn:
+                        description: Target iSCSI Qualified Name.
+                        type: string
+                      iscsiInterface:
+                        description: iSCSI Interface Name that uses an iSCSI transport.
+                          Defaults to 'default' (tcp).
+                        type: string
+                      lun:
+                        description: iSCSI Target Lun number.
+                        format: int32
+                        type: integer
+                      portals:
+                        description: iSCSI Target Portal List. The portal is either
+                          an IP or ip_addr:port if the port is other than default
+                          (typically TCP ports 860 and 3260).
+                        items:
+                          type: string
+                        type: array
+                      readOnly:
+                        description: ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false.
+                        type: boolean
+                      secretRef:
+                        description: CHAP Secret for iSCSI target and initiator authentication
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      targetPortal:
+                        description: iSCSI Target Portal. The Portal is either an
+                          IP or ip_addr:port if the port is other than default (typically
+                          TCP ports 860 and 3260).
+                        type: string
+                    required:
+                    - iqn
+                    - lun
+                    - targetPortal
+                    type: object
+                  name:
+                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
+                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  nfs:
+                    description: 'NFS represents an NFS mount on the host that shares
+                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    properties:
+                      path:
+                        description: 'Path that is exported by the NFS server. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the NFS export to be
+                          mounted with read-only permissions. Defaults to false. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: boolean
+                      server:
+                        description: 'Server is the hostname or IP address of the
+                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                    required:
+                    - path
+                    - server
+                    type: object
+                  persistentVolumeClaim:
+                    description: 'PersistentVolumeClaimVolumeSource represents a reference
+                      to a PersistentVolumeClaim in the same namespace. More info:
+                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                    properties:
+                      claimName:
+                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                          in the same namespace as the pod using this volume. More
+                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: string
+                      readOnly:
+                        description: Will force the ReadOnly setting in VolumeMounts.
+                          Default false.
+                        type: boolean
+                    required:
+                    - claimName
+                    type: object
+                  photonPersistentDisk:
+                    description: PhotonPersistentDisk represents a PhotonController
+                      persistent disk attached and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      pdID:
+                        description: ID that identifies Photon Controller persistent
+                          disk
+                        type: string
+                    required:
+                    - pdID
+                    type: object
+                  portworxVolume:
+                    description: PortworxVolume represents a portworx volume attached
+                      and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: FSType represents the filesystem type to mount
+                          Must be a filesystem type supported by the host operating
+                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                          if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      volumeID:
+                        description: VolumeID uniquely identifies a Portworx volume
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  projected:
+                    description: Items for all in one resources secrets, configmaps,
+                      and downward API
+                    properties:
+                      defaultMode:
+                        description: Mode bits to use on created files by default.
+                          Must be a value between 0 and 0777. Directories within the
+                          path are not affected by this setting. This might be in
+                          conflict with other options that affect the file mode, like
+                          fsGroup, and the result can be other mode bits set.
+                        format: int32
+                        type: integer
+                      sources:
+                        description: list of volume projections
+                        items:
+                          description: Projection that may be projected along with
+                            other supported volume types
+                          properties:
+                            configMap:
+                              description: information about the configMap data to
+                                project
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    keys must be defined
+                                  type: boolean
+                              type: object
+                            downwardAPI:
+                              description: information about the downwardAPI data
+                                to project
+                              properties:
+                                items:
+                                  description: Items is a list of DownwardAPIVolume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            secret:
+                              description: information about the secret data to project
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced Secret will
+                                    be projected into the volume as a file whose name
+                                    is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              type: object
+                            serviceAccountToken:
+                              description: information about the serviceAccountToken
+                                data to project
+                              properties:
+                                audience:
+                                  description: Audience is the intended audience of
+                                    the token. A recipient of a token must identify
+                                    itself with an identifier specified in the audience
+                                    of the token, and otherwise should reject the
+                                    token. The audience defaults to the identifier
+                                    of the apiserver.
+                                  type: string
+                                expirationSeconds:
+                                  description: ExpirationSeconds is the requested
+                                    duration of validity of the service account token.
+                                    As the token approaches expiration, the kubelet
+                                    volume plugin will proactively rotate the service
+                                    account token. The kubelet will start trying to
+                                    rotate the token if the token is older than 80
+                                    percent of its time to live or if the token is
+                                    older than 24 hours.Defaults to 1 hour and must
+                                    be at least 10 minutes.
+                                  format: int64
+                                  type: integer
+                                path:
+                                  description: Path is the path relative to the mount
+                                    point of the file to project the token into.
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                          type: object
+                        type: array
+                    required:
+                    - sources
+                    type: object
+                  quobyte:
+                    description: Quobyte represents a Quobyte mount on the host that
+                      shares a pod's lifetime
+                    properties:
+                      group:
+                        description: Group to map volume access to Default is no group
+                        type: string
+                      readOnly:
+                        description: ReadOnly here will force the Quobyte volume to
+                          be mounted with read-only permissions. Defaults to false.
+                        type: boolean
+                      registry:
+                        description: Registry represents a single or multiple Quobyte
+                          Registry services specified as a string as host:port pair
+                          (multiple entries are separated with commas) which acts
+                          as the central registry for volumes
+                        type: string
+                      tenant:
+                        description: Tenant owning the given Quobyte volume in the
+                          Backend Used with dynamically provisioned Quobyte volumes,
+                          value is set by the plugin
+                        type: string
+                      user:
+                        description: User to map volume access to Defaults to serivceaccount
+                          user
+                        type: string
+                      volume:
+                        description: Volume is a string that references an already
+                          created Quobyte volume by name.
+                        type: string
+                    required:
+                    - registry
+                    - volume
+                    type: object
+                  rbd:
+                    description: 'RBD represents a Rados Block Device mount on the
+                      host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      image:
+                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      keyring:
+                        description: 'Keyring is the path to key ring for RBDUser.
+                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      monitors:
+                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        items:
+                          type: string
+                        type: array
+                      pool:
+                        description: 'The rados pool name. Default is rbd. More info:
+                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: boolean
+                      secretRef:
+                        description: 'SecretRef is name of the authentication secret
+                          for RBDUser. If provided overrides keyring. Default is nil.
+                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      user:
+                        description: 'The rados user name. Default is admin. More
+                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - image
+                    - monitors
+                    type: object
+                  scaleIO:
+                    description: ScaleIO represents a ScaleIO persistent volume attached
+                      and mounted on Kubernetes nodes.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Default is "xfs".
+                        type: string
+                      gateway:
+                        description: The host address of the ScaleIO API Gateway.
+                        type: string
+                      protectionDomain:
+                        description: The name of the ScaleIO Protection Domain for
+                          the configured storage.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef references to the secret for ScaleIO
+                          user and other sensitive information. If this is not provided,
+                          Login operation will fail.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      sslEnabled:
+                        description: Flag to enable/disable SSL communication with
+                          Gateway, default false
+                        type: boolean
+                      storageMode:
+                        description: Indicates whether the storage for a volume should
+                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                        type: string
+                      storagePool:
+                        description: The ScaleIO Storage Pool associated with the
+                          protection domain.
+                        type: string
+                      system:
+                        description: The name of the storage system as configured
+                          in ScaleIO.
+                        type: string
+                      volumeName:
+                        description: The name of a volume already created in the ScaleIO
+                          system that is associated with this volume source.
+                        type: string
+                    required:
+                    - gateway
+                    - secretRef
+                    - system
+                    type: object
+                  secret:
+                    description: 'Secret represents a secret that should populate
+                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced Secret will be projected into the
+                          volume as a file whose name is the key and content is the
+                          value. If specified, the listed keys will be projected into
+                          the specified paths, and unlisted keys will not be present.
+                          If a key is specified which is not present in the Secret,
+                          the volume setup will error unless it is marked optional.
+                          Paths must be relative and may not contain the '..' path
+                          or start with '..'.
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          type: object
+                        type: array
+                      optional:
+                        description: Specify whether the Secret or its keys must be
+                          defined
+                        type: boolean
+                      secretName:
+                        description: 'Name of the secret in the pod''s namespace to
+                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: string
+                    type: object
+                  storageos:
+                    description: StorageOS represents a StorageOS volume attached
+                      and mounted on Kubernetes nodes.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef specifies the secret to use for obtaining
+                          the StorageOS API credentials.  If not specified, default
+                          values will be attempted.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      volumeName:
+                        description: VolumeName is the human-readable name of the
+                          StorageOS volume.  Volume names are only unique within a
+                          namespace.
+                        type: string
+                      volumeNamespace:
+                        description: VolumeNamespace specifies the scope of the volume
+                          within StorageOS.  If no namespace is specified then the
+                          Pod's namespace will be used.  This allows the Kubernetes
+                          name scoping to be mirrored within StorageOS for tighter
+                          integration. Set VolumeName to any name to override the
+                          default behaviour. Set to "default" if you are not using
+                          namespaces within StorageOS. Namespaces that do not pre-exist
+                          within StorageOS will be created.
+                        type: string
+                    type: object
+                  vsphereVolume:
+                    description: VsphereVolume represents a vSphere volume attached
+                      and mounted on kubelets host machine
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      storagePolicyID:
+                        description: Storage Policy Based Management (SPBM) profile
+                          ID associated with the StoragePolicyName.
+                        type: string
+                      storagePolicyName:
+                        description: Storage Policy Based Management (SPBM) profile
+                          name.
+                        type: string
+                      volumePath:
+                        description: Path that identifies vSphere volume vmdk
+                        type: string
+                    required:
+                    - volumePath
+                    type: object
+                required:
+                - name
+                type: object
+              type: array
           type: object
         status:
           description: ZookeeperClusterStatus defines the observed state of ZookeeperCluster

--- a/deploy/default_ns/operator.yaml
+++ b/deploy/default_ns/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: zookeeper-operator
           # Replace this with the built image name
-          image: pravega/zookeeper-operator:latest
+          image: pravega/zookeeper-operator:0.2.8
           ports:
           - containerPort: 60000
             name: metrics

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -201,6 +201,13 @@ func (s *ZookeeperClusterSpec) withDefaults(z *ZookeeperCluster) (changed bool) 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=zk
+// +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.spec.replicas`,description="The number of ZooKeeper servers in the ensemble"
+// +kubebuilder:printcolumn:name="Ready Replicas",type=integer,JSONPath=`.status.readyReplicas`,description="The number of ZooKeeper servers in the ensemble that are in a Ready state"
+// +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.currentVersion`,description="The current Zookeeper version"
+// +kubebuilder:printcolumn:name="Desired Version",type=string,JSONPath=`.spec.image.tag`,description="The desired Zookeeper version"
+// +kubebuilder:printcolumn:name="Internal Endpoint",type=string,JSONPath=`.status.internalClientEndpoint`,description="Client endpoint internal to cluster network"
+// +kubebuilder:printcolumn:name="External Endpoint",type=string,JSONPath=`.status.externalClientEndpoint`,description="Client endpoint external to cluster network via LoadBalancer"
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // ZookeeperCluster is the Schema for the zookeeperclusters API
 type ZookeeperCluster struct {

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -85,6 +85,12 @@ type ZookeeperClusterSpec struct {
 
 	// Domain of the kubernetes cluster, defaults to cluster.local
 	KubernetesClusterDomain string `json:"kubernetesClusterDomain,omitempty"`
+
+	// Containers defines to support multi containers
+	Containers []v1.Container `json:"containers,omitempty"`
+
+	// Volumes defines to support customized volumes
+	Volumes []v1.Volume `json:"volumes,omitempty"`
 }
 
 func (s *ZookeeperClusterSpec) withDefaults(z *ZookeeperCluster) (changed bool) {

--- a/pkg/apis/zookeeper/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/zookeeper/v1beta1/zz_generated.deepcopy.go
@@ -268,6 +268,20 @@ func (in *ZookeeperClusterSpec) DeepCopyInto(out *ZookeeperClusterSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	out.Conf = in.Conf
+	if in.Containers != nil {
+		in, out := &in.Containers, &out.Containers
+		*out = make([]v1.Container, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.Volumes != nil {
+		in, out := &in.Volumes, &out.Volumes
+		*out = make([]v1.Volume, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -156,9 +156,9 @@ func makeZkPodSpec(z *v1beta1.ZookeeperCluster, volumes []v1.Volume) v1.PodSpec 
 
 	zkContainer.Env = append(zkContainer.Env, z.Spec.Pod.Env...)
 	podSpec := v1.PodSpec{
-		Containers: []v1.Container{zkContainer},
+		Containers: append(z.Spec.Containers, zkContainer),
 		Affinity:   z.Spec.Pod.Affinity,
-		Volumes:    volumes,
+		Volumes:    append(z.Spec.Volumes, volumes...),
 	}
 	if reflect.DeepEqual(v1.PodSecurityContext{}, z.Spec.Pod.SecurityContext) {
 		podSpec.SecurityContext = z.Spec.Pod.SecurityContext


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Helm upgrade of the zookeeper operator and zookeeper cluster from 0.2.8 to 0.2.9-rc0 is failing. Also the `additionalPrinterColumns` from the ZookeeperCluster CRD have been removed.

### Purpose of the change
Fixed #241 

### What the code does
Changes the location of the CRD from the `crds/` since that was causing the operator upgrade from 0.2.8 to 0.2.9-rc0 to fail, and adds the `additionalPrinterColumns` back into the ZookeeperCluster CRD. Also adds default value for the `storageType` and `kubernetesClusterDomain` fields so that helm upgrade of the zookeeper cluster using the `reuse-values` flag does not fail.

### How to verify it
- Helm upgrade of zookeeper operator from 0.2.8 to 0.2.9-rc0 should succeed.
- Helm upgrade of zookeeper cluster from 0.2.8 0.2.9-rc0 should succeed both with and without the reuse-values flag.
