### PR TITLE
Use getent instead of nslookup for starting scripts

### DIFF
--- a/docker/bin/zookeeperFunctions.sh
+++ b/docker/bin/zookeeperFunctions.sh
@@ -19,8 +19,8 @@ function zkConfig() {
 function zkConnectionString() {
   # If the client service address is not yet available, then return localhost
   set +e
-  nslookup "${CLIENT_HOST}" 2>/dev/null 1>/dev/null
-  if [[ $? -eq 1 ]]; then
+  getent hosts "${CLIENT_HOST}" 2>/dev/null 1>/dev/null
+  if [[ $? -ne 0 ]]; then
     set -e
     echo "localhost:${CLIENT_PORT}"
   else

--- a/docker/bin/zookeeperReady.sh
+++ b/docker/bin/zookeeperReady.sh
@@ -25,8 +25,8 @@ OK=$(echo ruok | nc 127.0.0.1 $CLIENT_PORT)
 # Check to see if zookeeper service answers
 if [[ "$OK" == "imok" ]]; then
   set +e
-  nslookup $DOMAIN
-  if [[ $? -eq 1 ]]; then
+  getent hosts $DOMAIN
+  if [[ $? -ne 0 ]]; then
     set -e
     echo "There is no active ensemble, skipping readiness probe..."
     exit 0

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -69,9 +69,9 @@ if [[ -n "$ENVOY_SIDECAR_STATUS" ]]; then
 fi
 set -e
 
-# Determine if there is a ensemble available to join by checking the service domain
+# Determine if there is an ensemble available to join by checking the service domain
 set +e
-nslookup $DOMAIN
+getent hosts $DOMAIN  # This only performs a dns lookup
 if [[ $? -eq 0 ]]; then
   ACTIVE_ENSEMBLE=true
 elif nslookup $DOMAIN | grep -q "server can't find $DOMAIN"; then
@@ -87,7 +87,7 @@ else
   do
     sleep 2
     ((count=count-1))
-    nslookup $DOMAIN
+    getent hosts $DOMAIN
     if [[ $? -eq 0 ]]; then
       ACTIVE_ENSEMBLE=true
       break


### PR DESCRIPTION
The nslookup only exit with status 0 with successful lookup of dns record for both forward and backward lookups. It would mean that the cluster's DNS setup has to support. `getent` only performs a forward lookup.

pravega#76