### PR TITLE
Issue 240: Bootstrap Process does not handle missing DNS server correctly

### DIFF
--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -93,7 +93,6 @@ else
       break
     fi
   done
-
 fi
 
 if [[ "$ONDISK_MYID_CONFIG" == true && "$ONDISK_DYN_CONFIG" == true ]]; then

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -72,13 +72,18 @@ set -e
 # Determine if there is a ensemble available to join by checking the service domain
 set +e
 nslookup $DOMAIN
-if [[ $? -eq 1 ]]; then
+if [[ $? -eq 0 ]]; then
+  ACTIVE_ENSEMBLE=true
+elif nslookup $DOMAIN | grep -q "server can't find $DOMAIN"; then
+   echo "there is no active ensemble"
+   ACTIVE_ENSEMBLE=false
+else
   # If an nslookup of the headless service domain fails, then there is no
   # active ensemble yet, but in certain cases nslookup of headless service
   # takes a while to come up even if there is active ensemble
   ACTIVE_ENSEMBLE=false
   declare -i count=20
-  while [[ $count -ge 0 && $MYID -ne 1 ]]
+  while [[ $count -ge 0 ]]
   do
     sleep 2
     ((count=count-1))
@@ -88,8 +93,7 @@ if [[ $? -eq 1 ]]; then
       break
     fi
   done
-else
-  ACTIVE_ENSEMBLE=true
+
 fi
 
 if [[ "$ONDISK_MYID_CONFIG" == true && "$ONDISK_DYN_CONFIG" == true ]]; then


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description

Fix is added to parse nslookup  output to differentiate lookup failure and DNS failure.

### Purpose of the change

Fixes #240

### What the code does

In some scenarios, like DNS servers are not ready , nslookup  was fialing. In the code we were handling it for all the nodes except the first node. In case of DR , the node that is shutdown is the node containing `zookeeper-0`,  nslookup failure is causing split brain situation and it is creating a new cluster. 

Fix is added to parse the nslookup output and differentiate DNS failure vs lookup failure.

### How to verify it
Verified, restart of of zookeeper pods, scale up and down.
In baremetal cluster deleted node containing zookeeper-0.
