### PR TITLE
Issue 250: Not specifying a default storageclass

### DIFF
--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -77,7 +77,7 @@ The following table lists the configurable parameters of the zookeeper chart and
 | `config.quorumListenOnAllIPs` | Whether Zookeeper server will listen for connections from its peers on all available IP addresses | `false` |
 | `storageType` | Type of storage that can be used it can take either ephemeral or persistence as value | `persistence` |
 | `persistence.reclaimPolicy` | Reclaim policy for persistent volumes | `Delete` |
-| `persistence.storageClassName` | Storage class for persistent volumes | `standard` |
+| `persistence.storageClassName` | Storage class for persistent volumes | `` |
 | `persistence.volumeSize` | Size of the volume requested for persistent volumes | `20Gi` |
 | `ephemeral.emptydirvolumesource.medium` |  What type of storage medium should back the directory. | `""` |
 | `ephemeral.emptydirvolumesource.sizeLimit` | Total amount of local storage required for the EmptyDir volume. | `20Gi` |

--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -93,9 +93,15 @@ spec:
   {{- else }}
   persistence:
     reclaimPolicy: {{ .Values.persistence.reclaimPolicy }}
+    {{- if or .Values.persistence.storageClassName .Values.persistence.volumeSize }}
     spec:
+      {{- if .Values.persistence.storageClassName }}
       storageClassName: {{ .Values.persistence.storageClassName }}
+      {{- end }}
+      {{- if .Values.persistence.volumeSize }}
       resources:
         requests:
           storage: {{ .Values.persistence.volumeSize }}
+      {{- end }}
+    {{- end }}
   {{- end }}

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -33,7 +33,7 @@ config: {}
 storageType: persistence
 
 persistence:
-  storageClassName: standard
+  storageClassName:
   ## specifying reclaim policy for PersistentVolumes
   ## accepted values - Delete / Retain
   reclaimPolicy: Delete


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Does not specify any default value for storageclass which allows the default storageclass for the given environment to be picked instead of having to hard-code it.

### Purpose of the change
Fixes #250 

### How to verify it
Install the zookeeper charts which do not specify any value for the storageclass. The following command shows that the default storageclass for the environment will be automatically picked.
```
$ kubectl get storageclass
NAME                 PROVISIONER                                       AGE
nfs                  cluster.local/nfs-server-provisioner-1599805455   25d
standard (default)   kubernetes.io/vsphere-volume                      25d

$ kubectl get pvc
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
data-zookeeper-0        Bound    pvc-6120fb84-919b-402b-812b-834b79edc649   20Gi       RWO            standard       69m
data-zookeeper-1        Bound    pvc-0de5bc53-e6a5-40ba-8b8e-d7d65a1bcc85   20Gi       RWO            standard       68m
data-zookeeper-2        Bound    pvc-0b6d6218-7c78-4496-b711-f27d006c88aa   20Gi       RWO            standard       68m

```
