### PR TITLE
Issue78: Allow to set a SeviceAccount to cluster Statefulset 

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ svc/zookeeper-client     ClusterIP   10.31.243.173   <none>        2181/TCP     
 svc/zookeeper-headless   ClusterIP   None            <none>        2888/TCP,3888/TCP   2m
 ```
 
+>Note: If you want to configure non deafult service accounts to zookeeper pods, refer to [this](doc/rbac.md).
+
 ### Deploy a sample Zookeeper cluster with Ephemeral storage
 
 Create a Yaml file called `zk.yaml` with the following content to install a 3-node Zookeeper cluster.

--- a/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -2275,6 +2275,9 @@ spec:
                           type: string
                       type: object
                   type: object
+                serviceAccountName:
+                  description: Service Account to be used in pods
+                  type: string
                 terminationGracePeriodSeconds:
                   description: TerminationGracePeriodSeconds is the amount of time
                     that kubernetes will give for a pod instance to shutdown normally.

--- a/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -636,7 +636,9 @@ spec:
                     type: array
                     x-kubernetes-list-map-keys:
                     - containerPort
+                    {{- if semverCompare "< 1.18-0" .Capabilities.KubeVersion.GitVersion }}
                     - protocol
+                    {{- end }}
                     x-kubernetes-list-type: map
                   readinessProbe:
                     description: 'Periodic probe of container service readiness. Container

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -8,8 +8,8 @@ global:
   # - private-registry-key
 
 image:
-  repository: pravega/zookeeper-operator
-  tag: 0.2.8
+  repository: kjanisha/zookeeper-operator
+  tag: openshift2 
   pullPolicy: IfNotPresent
 
 ## Install RBAC roles and bindings.

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -8,8 +8,8 @@ global:
   # - private-registry-key
 
 image:
-  repository: kjanisha/zookeeper-operator
-  tag: openshift2 
+  repository: pravega/zookeeper-operator
+  tag: 0.2.8
   pullPolicy: IfNotPresent
 
 ## Install RBAC roles and bindings.

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -71,6 +71,7 @@ The following table lists the configurable parameters of the zookeeper chart and
 | `pod.annotations` | Specifies the annotations to attach to pods | `{}` |
 | `pod.securityContext` | Specifies the security context for the entire pod | `{}` |
 | `pod.terminationGracePeriodSeconds` | Amount of time given to the pod to shutdown normally | `30` |
+| `pod.serviceAccountName` | Name for the service account | `zookeeper` |
 | `config.initLimit` | Amount of time (in ticks) to allow followers to connect and sync to a leader | `10` |
 | `config.tickTime` | Length of a single tick which is the basic time unit used by Zookeeper (measured in milliseconds) | `2000` |
 | `config.syncLimit` | Amount of time (in ticks) to allow followers to sync with Zookeeper | `2` |

--- a/charts/zookeeper/templates/clusterrole.yaml
+++ b/charts/zookeeper/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ default "zookeeper" .Values.pod.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "zookeeper.commonLabels" . | indent 4 }}

--- a/charts/zookeeper/templates/clusterrole.yaml
+++ b/charts/zookeeper/templates/clusterrole.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "zookeeper.commonLabels" . | indent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get

--- a/charts/zookeeper/templates/clusterrolebinding.yaml
+++ b/charts/zookeeper/templates/clusterrolebinding.yaml
@@ -1,15 +1,15 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ default "zookeeper" .Values.pod.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "zookeeper.commonLabels" . | indent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ default "zookeeper" .Values.pod.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ default "zookeeper" .Values.pod.serviceAccountName }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/zookeeper/templates/clusterrolebinding.yaml
+++ b/charts/zookeeper/templates/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "zookeeper.commonLabels" . | indent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.serviceAccount.name }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/zookeeper/templates/role.yaml
+++ b/charts/zookeeper/templates/role.yaml
@@ -1,7 +1,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name:{{ default "zookeeper" .Values.pod.serviceAccountName }}
+  name: {{ default "zookeeper" .Values.pod.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "zookeeper.commonLabels" . | indent 4 }}

--- a/charts/zookeeper/templates/role.yaml
+++ b/charts/zookeeper/templates/role.yaml
@@ -1,7 +1,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name:{{ default "zookeeper" .Values.pod.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "zookeeper.commonLabels" . | indent 4 }}

--- a/charts/zookeeper/templates/role.yaml
+++ b/charts/zookeeper/templates/role.yaml
@@ -1,0 +1,21 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "zookeeper.commonLabels" . | indent 4 }}
+rules:
+- apiGroups:
+  - zookeeper.pravega.io
+  resources:
+  - "*"
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  verbs:
+  - get

--- a/charts/zookeeper/templates/rolebinding.yaml
+++ b/charts/zookeeper/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "zookeeper.commonLabels" . | indent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Values.serviceAccount.name }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/zookeeper/templates/rolebinding.yaml
+++ b/charts/zookeeper/templates/rolebinding.yaml
@@ -1,15 +1,15 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ default "zookeeper" .Values.pod.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "zookeeper.commonLabels" . | indent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ default "zookeeper" .Values.pod.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ default "zookeeper" .Values.pod.serviceAccountName }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/zookeeper/templates/service_account.yaml
+++ b/charts/zookeeper/templates/service_account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ default "zookeeper" .Values.pod.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "zookeeper.commonLabels" . | indent 4 }}

--- a/charts/zookeeper/templates/service_account.yaml
+++ b/charts/zookeeper/templates/service_account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "zookeeper.commonLabels" . | indent 4 }}

--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -64,6 +64,9 @@ spec:
     {{- if .Values.pod.terminationGracePeriodSeconds }}
     terminationGracePeriodSeconds: {{ .Values.pod.terminationGracePeriodSeconds }}
     {{- end }}
+    {{- if .Values.pod.serviceAccountName }}
+    serviceAccountName: {{ .Values.pod.serviceAccountName }}
+    {{- end }}
   {{- end }}
   {{- if .Values.config }}
   config:

--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -27,7 +27,6 @@ spec:
 {{ toYaml .Values.labels | indent 4 }}
   ports:
 {{ toYaml .Values.ports | indent 4 }}
-  {{- if .Values.pod }}
   pod:
     {{- if .Values.pod.labels }}
     labels:
@@ -64,10 +63,7 @@ spec:
     {{- if .Values.pod.terminationGracePeriodSeconds }}
     terminationGracePeriodSeconds: {{ .Values.pod.terminationGracePeriodSeconds }}
     {{- end }}
-    {{- if .Values.pod.serviceAccountName }}
-    serviceAccountName: {{ .Values.pod.serviceAccountName }}
-    {{- end }}
-  {{- end }}
+    serviceAccountName: {{ default "zookeeper" .Values.pod.serviceAccountName }}
   {{- if .Values.config }}
   config:
     {{- if .Values.config.initLimit }}

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -20,7 +20,7 @@ pod:
   # annotations: {}
   # securityContext: {}
   # terminationGracePeriodSeconds: 30
-  serviceAccountName: zookeeper-operator
+  serviceAccountName: zookeeper
 
 config: {}
   # initLimit: 10

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -10,7 +10,7 @@ labels: {}
 ports: []
 kubernetesClusterDomain: "cluster.local"
 
-pod: {}
+pod:
   # labels: {}
   # nodeSelector: {}
   # affinity: {}
@@ -20,6 +20,7 @@ pod: {}
   # annotations: {}
   # securityContext: {}
   # terminationGracePeriodSeconds: 30
+  serviceAccountName: zookeeper-operator
 
 config: {}
   # initLimit: 10

--- a/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -635,7 +635,6 @@ spec:
                     type: array
                     x-kubernetes-list-map-keys:
                     - containerPort
-                    - protocol
                     x-kubernetes-list-type: map
                   readinessProbe:
                     description: 'Periodic probe of container service readiness. Container

--- a/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -2274,6 +2274,9 @@ spec:
                           type: string
                       type: object
                   type: object
+                serviceAccountName:
+                  description: Service Account to be used in pods
+                  type: string
                 terminationGracePeriodSeconds:
                   description: TerminationGracePeriodSeconds is the amount of time
                     that kubernetes will give for a pod instance to shutdown normally.

--- a/doc/rbac.md
+++ b/doc/rbac.md
@@ -1,0 +1,92 @@
+## Setting up RBAC for zookeeper stateful set
+### Use non-default service accounts
+
+From zookeeper operator version `0.2.9` onwards, support is added to configure non deault service accounts for zookeeper pods.
+
+Below are the steps
+
+1. Create a service account in the namespace where you want to deploy zookeeper cluster
+
+```
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zookeeper
+```
+
+2. Create `Role` and `ClusterRole` with the minimum required permissions. Make sure to update the `default` namespace if you are deploying zookeeper to a custom namespace.
+
+```
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: zookeeper
+  namespace: "default"
+rules:
+- apiGroups: ["zookeeper.pravega.io"]
+  resources: ["*"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["pods", "services"]
+  verbs: ["get"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: zookeeper
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+```
+3. Bind roles and cluster roles to the service account.
+
+```
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: zookeeper
+subjects:
+- kind: ServiceAccount
+  name: zookeeper
+roleRef:
+  kind: Role
+  name: zookeeper
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: zookeeper
+subjects:
+- kind: ServiceAccount
+  name: zookeeper
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: zookeeper
+  apiGroup: rbac.authorization.k8s.io
+```
+
+4. Create zookeeper cluster
+  ```
+  apiVersion: zookeeper.pravega.io/v1beta1
+  kind: ZookeeperCluster
+  metadata:
+    name: zookeeper
+  spec:
+    replicas: 3
+    image:
+      repository: pravega/zookeeper
+      tag: 0.2.9
+    pod:
+      serviceAccountName: zookeeper  
+    storageType: persistence
+    persistence:
+      reclaimPolicy: Delete
+      spec:
+        storageClassName: "standard"
+        resources:
+          requests:
+            storage: 20Gi
+```

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,9 @@ require (
 	github.com/onsi/gomega v1.9.0
 	github.com/operator-framework/operator-sdk v0.17.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/common v0.9.1
 	github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da
+	github.com/sirupsen/logrus v1.5.0
 	github.com/stripe/safesql v0.2.0 // indirect
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
 	golang.org/x/tools v0.0.0-20200331202046-9d5940d49312 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,9 +75,11 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aliyun/aliyun-oss-go-sdk v2.0.4+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
@@ -1077,6 +1079,7 @@ google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRn
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"strings"
 
-	log1 "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -342,8 +341,6 @@ type PodPolicy struct {
 }
 
 func (p *PodPolicy) withDefaults(z *ZookeeperCluster) (changed bool) {
-	log1.Info("I amin pod policy defaults")
-	log1.Printf("service account is %v", p.ServiceAccountName)
 	if p.Labels == nil {
 		p.Labels = map[string]string{}
 		changed = true
@@ -353,7 +350,7 @@ func (p *PodPolicy) withDefaults(z *ZookeeperCluster) (changed bool) {
 		changed = true
 	}
 	if p.ServiceAccountName == "" {
-		p.ServiceAccountName = "default"
+		p.ServiceAccountName = "zookeeper"
 		changed = true
 	}
 	if z.Spec.Pod.Labels == nil {

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -350,7 +350,7 @@ func (p *PodPolicy) withDefaults(z *ZookeeperCluster) (changed bool) {
 		changed = true
 	}
 	if p.ServiceAccountName == "" {
-		p.ServiceAccountName = "zookeeper"
+		p.ServiceAccountName = "default"
 		changed = true
 	}
 	if z.Spec.Pod.Labels == nil {

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"strings"
 
+	log1 "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -336,15 +337,23 @@ type PodPolicy struct {
 	// give for a pod instance to shutdown normally.
 	// The default value is 30.
 	TerminationGracePeriodSeconds int64 `json:"terminationGracePeriodSeconds,omitempty"`
+	// Service Account to be used in pods
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 func (p *PodPolicy) withDefaults(z *ZookeeperCluster) (changed bool) {
+	log1.Info("I amin pod policy defaults")
+	log1.Printf("service account is %v", p.ServiceAccountName)
 	if p.Labels == nil {
 		p.Labels = map[string]string{}
 		changed = true
 	}
 	if p.TerminationGracePeriodSeconds == 0 {
 		p.TerminationGracePeriodSeconds = DefaultTerminationGracePeriod
+		changed = true
+	}
+	if p.ServiceAccountName == "" {
+		p.ServiceAccountName = "default"
 		changed = true
 	}
 	if z.Spec.Pod.Labels == nil {

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -166,6 +166,8 @@ func makeZkPodSpec(z *v1beta1.ZookeeperCluster, volumes []v1.Volume) v1.PodSpec 
 	podSpec.NodeSelector = z.Spec.Pod.NodeSelector
 	podSpec.Tolerations = z.Spec.Pod.Tolerations
 	podSpec.TerminationGracePeriodSeconds = &z.Spec.Pod.TerminationGracePeriodSeconds
+	podSpec.ServiceAccountName = z.Spec.Pod.ServiceAccountName
+
 	return podSpec
 }
 


### PR DESCRIPTION
### Change log description

Added a new field service account in podspec so that users will be able to create pods with  non default service accounts

### Purpose of the change

 Fixes #78

### What the code does
Added service account to pod spec. And added corresponding changes in zookeeper cluster charts.
### How to verify it

Verified the zookeeper operator and cluster installation
Verified zookeeper operator and cluster upgrades