### PR TITLE
Issue 125: Pass PodPolicy annotations from ZookeeperClusterSpec to StatefulSet Pod Templates.

### DIFF
--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -95,6 +95,7 @@ func MakeStatefulSet(z *v1beta1.ZookeeperCluster) *appsv1.StatefulSet {
 							"kind": "ZookeeperMember",
 						},
 					),
+					Annotations: z.Spec.Pod.Annotations,
 				},
 				Spec: makeZkPodSpec(z, extraVolumes),
 			},

--- a/pkg/zk/generators_test.go
+++ b/pkg/zk/generators_test.go
@@ -196,6 +196,33 @@ var _ = Describe("Generators Spec", func() {
 					"exampleValue"))
 			})
 		})
+		
+		Context("with pod policy annotations", func() {
+
+			BeforeEach(func() {
+				z := &v1beta1.ZookeeperCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "example",
+						Namespace: "default",
+					},
+					Spec: v1beta1.ZookeeperClusterSpec{
+						Pod: v1beta1.PodPolicy{
+							Annotations: map[string]string{
+								"example-annotation": "example-value",
+							},
+						},
+					},
+				}
+				z.WithDefaults()
+				sts = zk.MakeStatefulSet(z)
+			})
+
+			It("should have custom labels set on pods", func() {
+				Ω(sts.Spec.Template.ObjectMeta.Annotations).To(HaveKeyWithValue(
+					"example-annotation",
+					"example-value"))
+			})
+		})
 	})
 
 	Context("#MakeStatefulSet with Ephemeral storage", func() {

--- a/pkg/zk/generators_test.go
+++ b/pkg/zk/generators_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Generators Spec", func() {
 					"exampleValue"))
 			})
 		})
-		
+
 		Context("with pod policy annotations", func() {
 
 			BeforeEach(func() {


### PR DESCRIPTION
Signed-off-by: Oliver Maskery <oliver@wellplayed.games>

### Change log description

Pass annotations specified in ZookeeperCluster's Pod Policy to the StatefulSet's pod template.

### Purpose of the change

Closes #125 

### What the code does

The ZookeeperClusterSpec already has a PodPolicy which contains an Annotations `map[string]string`, this PR simply passes it through into the constructed StatefulSet's pod template.

### How to verify it

**Given** a ZookeeperCluster resource has annotations in its Spec.Pod.Annotations
**And** this resource is applied to a Kubernetes cluster
**When** the Zookeeper Operator reconciles the ZookeeperCluster resource
**Then** a StatefulSet is created
**And** the StatefulSet's Pod Template has the requested annotations
**And** the Pods created by the StatefulSet have the requested annotations