### PR TITLE
Fix marker comments for runtime object deepcopy

### DIFF
--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -194,9 +194,6 @@ func (s *ZookeeperClusterSpec) withDefaults(z *ZookeeperCluster) (changed bool) 
 	return changed
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +k8s:openapi-gen=true
-
 // Generate CRD using kubebuilder
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
@@ -208,6 +205,8 @@ func (s *ZookeeperClusterSpec) withDefaults(z *ZookeeperCluster) (changed bool) 
 // +kubebuilder:printcolumn:name="Internal Endpoint",type=string,JSONPath=`.status.internalClientEndpoint`,description="Client endpoint internal to cluster network"
 // +kubebuilder:printcolumn:name="External Endpoint",type=string,JSONPath=`.status.externalClientEndpoint`,description="Client endpoint external to cluster network via LoadBalancer"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +k8s:openapi-gen=true
 
 // ZookeeperCluster is the Schema for the zookeeperclusters API
 type ZookeeperCluster struct {


### PR DESCRIPTION
### Change log description

Fix marker comments for runtime object deepcopy.

### Purpose of the change

The marker comments for runtime object deepcopy was wrongly located. As such, the runtime object deepcopy code was not generated via `operator-sdk generate k8s` as expected. This change fixes the issue.

### What the code does

Fix location of marker comments for runtime object deepcopy so that the deepcopy code gets generated correctly.

### How to verify it

`operator-sdk generate k8s` should generate runtime object deepcopy code correctly.
