### PR TITLE
Issue 220: Added support for more zookeeper configuration options

### DIFF
--- a/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -64,81 +64,86 @@ spec:
           description: ZookeeperClusterSpec defines the desired state of ZookeeperCluster
           properties:
             config:
-              autoPurgePurgeInterval:
-                description: "The time interval in hours for which the purge task
-                  has to be triggered \n Disabled by default"
-                type: integer
-              autoPurgeSnapRetainCount:
-                description: "Retain the snapshots according to retain count \n
-                  The default value is 3"
-                type: integer
-              commitLogCount:
-                description: "Zookeeper maintains an in-memory list of last committed
-                  requests for fast synchronization with followers \n The default
-                  value is 500"
-                type: integer
-              globalOutstandingLimit:
-                description: "Clients can submit requests faster than ZooKeeper
-                  can process them, especially if there are a lot of clients. Zookeeper
-                  will throttle Clients so that requests won't exceed global outstanding
-                  limit. \n The default value is 1000"
-                type: integer
-              initLimit:
-                description: "InitLimit is the amount of time, in ticks, to allow
-                  followers to connect and sync to a leader. \n Default value is
-                  10."
-                type: integer
-              maxClientCnxns:
-                description: "Limits the number of concurrent connections that a
-                  single client, identified by IP address, may make to a single
-                  member of the ZooKeeper ensemble. \n The default value is 60"
-                type: integer
-              maxCnxns:
-                description: "Limits the total number of concurrent connections
-                  that can be made to a zookeeper server \n The defult value is
-                  0, indicating no limit"
-                type: integer
-              maxSessionTimeout:
-                description: "The maximum session timeout in milliseconds that the
-                  server will allow the client to negotiate. \n The default value
-                  is 40000"
-                type: integer
-              minSessionTimeout:
-                description: "The minimum session timeout in milliseconds that the
-                  server will allow the client to negotiate \n The default value
-                  is 4000"
-                type: integer
-              preAllocSize:
-                description: "To avoid seeks ZooKeeper allocates space in the transaction
-                  log file in blocks of preAllocSize kilobytes \n The default value
-                  is 64M"
-                type: integer
-              quorumListenOnAllIPs:
-                description: "QuorumListenOnAllIPs when set to true the ZooKeeper
-                  server will listen for connections from its peers on all available
-                  IP addresses, and not only the address configured in the server
-                  list of the configuration file. It affects the connections handling
-                  the ZAB protocol and the Fast Leader Election protocol. \n The
-                  default value is false."
-                type: boolean
-              snapCount:
-                description: "ZooKeeper records its transactions using snapshots
-                  and a transaction log The number of transactions recorded in the
-                  transaction log before a snapshot can be taken is determined by
-                  snapCount \n The default value is 100,000"
-                type: integer
-              snapSizeLimitInKb:
-                description: "Snapshot size limit in Kb \n The defult value is 4GB"
-                type: integer
-              syncLimit:
-                description: "SyncLimit is the amount of time, in ticks, to allow
-                  followers to sync with Zookeeper. \n The default value is 2."
-                type: integer
-              tickTime:
-                description: "TickTime is the length of a single tick, which is
-                  the basic time unit used by Zookeeper, as measured in milliseconds
-                  \n The default value is 2000."
-                type: integer
+              description: Conf is the zookeeper configuration, which will be used
+                to generate the static zookeeper configuration. If no configuration
+                is provided required default values will be provided, and optional
+                values will be excluded.
+              properties:
+                autoPurgePurgeInterval:
+                  description: "The time interval in hours for which the purge task
+                    has to be triggered \n Disabled by default"
+                  type: integer
+                autoPurgeSnapRetainCount:
+                  description: "Retain the snapshots according to retain count \n
+                    The default value is 3"
+                  type: integer
+                commitLogCount:
+                  description: "Zookeeper maintains an in-memory list of last committed
+                    requests for fast synchronization with followers \n The default
+                    value is 500"
+                  type: integer
+                globalOutstandingLimit:
+                  description: "Clients can submit requests faster than ZooKeeper
+                    can process them, especially if there are a lot of clients. Zookeeper
+                    will throttle Clients so that requests won't exceed global outstanding
+                    limit. \n The default value is 1000"
+                  type: integer
+                initLimit:
+                  description: "InitLimit is the amount of time, in ticks, to allow
+                    followers to connect and sync to a leader. \n Default value is
+                    10."
+                  type: integer
+                maxClientCnxns:
+                  description: "Limits the number of concurrent connections that a
+                    single client, identified by IP address, may make to a single
+                    member of the ZooKeeper ensemble. \n The default value is 60"
+                  type: integer
+                maxCnxns:
+                  description: "Limits the total number of concurrent connections
+                    that can be made to a zookeeper server \n The defult value is
+                    0, indicating no limit"
+                  type: integer
+                maxSessionTimeout:
+                  description: "The maximum session timeout in milliseconds that the
+                    server will allow the client to negotiate. \n The default value
+                    is 40000"
+                  type: integer
+                minSessionTimeout:
+                  description: "The minimum session timeout in milliseconds that the
+                    server will allow the client to negotiate \n The default value
+                    is 4000"
+                  type: integer
+                preAllocSize:
+                  description: "To avoid seeks ZooKeeper allocates space in the transaction
+                    log file in blocks of preAllocSize kilobytes \n The default value
+                    is 64M"
+                  type: integer
+                quorumListenOnAllIPs:
+                  description: "QuorumListenOnAllIPs when set to true the ZooKeeper
+                    server will listen for connections from its peers on all available
+                    IP addresses, and not only the address configured in the server
+                    list of the configuration file. It affects the connections handling
+                    the ZAB protocol and the Fast Leader Election protocol. \n The
+                    default value is false."
+                  type: boolean
+                snapCount:
+                  description: "ZooKeeper records its transactions using snapshots
+                    and a transaction log The number of transactions recorded in the
+                    transaction log before a snapshot can be taken is determined by
+                    snapCount \n The default value is 100,000"
+                  type: integer
+                snapSizeLimitInKb:
+                  description: "Snapshot size limit in Kb \n The defult value is 4GB"
+                  type: integer
+                syncLimit:
+                  description: "SyncLimit is the amount of time, in ticks, to allow
+                    followers to sync with Zookeeper. \n The default value is 2."
+                  type: integer
+                tickTime:
+                  description: "TickTime is the length of a single tick, which is
+                    the basic time unit used by Zookeeper, as measured in milliseconds
+                    \n The default value is 2000."
+                  type: integer
               type: object
             containers:
               description: Containers defines to support multi containers

--- a/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -64,83 +64,81 @@ spec:
           description: ZookeeperClusterSpec defines the desired state of ZookeeperCluster
           properties:
             config:
-              description: Conf is the zookeeper configuration, which will be used
-                to generate the static zookeeper configuration. If no configuration
-                is provided required default values will be provided, and optional
-                values will be excluded.
-              properties:
-                commitLogCount:
-                  description: "Zookeeper maintains an in-memory list of last committed
-                    requests for fast synchronization with followers \n The default
-                    value is 500"
-                  type: integer
-                globalOutstandingLimit:
-                  description: "Clients can submit requests faster than ZooKeeper
-                    can process them, especially if there are a lot of clients. Zookeeper
-                    will throttle Clients so that requests won't exceed global outstanding
-                    limit. \n The default value is 1000"
-                  type: integer
-                initLimit:
-                  description: "InitLimit is the amount of time, in ticks, to allow
-                    followers to connect and sync to a leader. \n Default value is
-                    10."
-                  type: integer
-                maxClientCnxns:
-                  description: "Limits the number of concurrent connections that a
-                    single client, identified by IP address, may make to a single
-                    member of the ZooKeeper ensemble. \n The default value is 60"
-                  type: integer
-                maxCnxns:
-                  description: "Limits the total number of concurrent connections
-                    that can be made to a zookeeper server \n The defult value is
-                    0, indicating no limit"
-                  type: integer
-                maxSessionTimeout:
-                  description: "the maximum session timeout in milliseconds that the
-                    server will allow the client to negotiate. \n The default value
-                    is 40000"
-                  type: integer
-                minSessionTimeout:
-                  type: integer
-                preAllocSize:
-                  description: "To avoid seeks ZooKeeper allocates space in the transaction
-                    log file in blocks of preAllocSize kilobytes \n The default value
-                    is 64M"
-                  type: integer
-                purgeInterval:
-                  description: "The time interval in hours for which the purge task
-                    has to be triggered \n Disabled by default"
-                  type: integer
-                quorumListenOnAllIPs:
-                  description: "QuorumListenOnAllIPs when set to true the ZooKeeper
-                    server will listen for connections from its peers on all available
-                    IP addresses, and not only the address configured in the server
-                    list of the configuration file. It affects the connections handling
-                    the ZAB protocol and the Fast Leader Election protocol. \n The
-                    default value is false."
-                  type: boolean
-                snapCount:
-                  description: "ZooKeeper records its transactions using snapshots
-                    and a transaction log The number of transactions recorded in the
-                    transaction log before a snapshot can be taken is determined by
-                    snapCount \n The default value is 100,000"
-                  type: integer
-                snapRetainCount:
-                  description: "Retain the snapshots according to retain count \n
-                    The default valueis 3"
-                  type: integer
-                snapSizeLimitInKb:
-                  description: "Snapshot size limit \n The defult value is 4GB"
-                  type: integer
-                syncLimit:
-                  description: "SyncLimit is the amount of time, in ticks, to allow
-                    followers to sync with Zookeeper. \n The default value is 2."
-                  type: integer
-                tickTime:
-                  description: "TickTime is the length of a single tick, which is
-                    the basic time unit used by Zookeeper, as measured in milliseconds
-                    \n The default value is 2000."
-                  type: integer
+              autoPurgePurgeInterval:
+                description: "The time interval in hours for which the purge task
+                  has to be triggered \n Disabled by default"
+                type: integer
+              autoPurgeSnapRetainCount:
+                description: "Retain the snapshots according to retain count \n
+                  The default value is 3"
+                type: integer
+              commitLogCount:
+                description: "Zookeeper maintains an in-memory list of last committed
+                  requests for fast synchronization with followers \n The default
+                  value is 500"
+                type: integer
+              globalOutstandingLimit:
+                description: "Clients can submit requests faster than ZooKeeper
+                  can process them, especially if there are a lot of clients. Zookeeper
+                  will throttle Clients so that requests won't exceed global outstanding
+                  limit. \n The default value is 1000"
+                type: integer
+              initLimit:
+                description: "InitLimit is the amount of time, in ticks, to allow
+                  followers to connect and sync to a leader. \n Default value is
+                  10."
+                type: integer
+              maxClientCnxns:
+                description: "Limits the number of concurrent connections that a
+                  single client, identified by IP address, may make to a single
+                  member of the ZooKeeper ensemble. \n The default value is 60"
+                type: integer
+              maxCnxns:
+                description: "Limits the total number of concurrent connections
+                  that can be made to a zookeeper server \n The defult value is
+                  0, indicating no limit"
+                type: integer
+              maxSessionTimeout:
+                description: "The maximum session timeout in milliseconds that the
+                  server will allow the client to negotiate. \n The default value
+                  is 40000"
+                type: integer
+              minSessionTimeout:
+                description: "The minimum session timeout in milliseconds that the
+                  server will allow the client to negotiate \n The default value
+                  is 4000"
+                type: integer
+              preAllocSize:
+                description: "To avoid seeks ZooKeeper allocates space in the transaction
+                  log file in blocks of preAllocSize kilobytes \n The default value
+                  is 64M"
+                type: integer
+              quorumListenOnAllIPs:
+                description: "QuorumListenOnAllIPs when set to true the ZooKeeper
+                  server will listen for connections from its peers on all available
+                  IP addresses, and not only the address configured in the server
+                  list of the configuration file. It affects the connections handling
+                  the ZAB protocol and the Fast Leader Election protocol. \n The
+                  default value is false."
+                type: boolean
+              snapCount:
+                description: "ZooKeeper records its transactions using snapshots
+                  and a transaction log The number of transactions recorded in the
+                  transaction log before a snapshot can be taken is determined by
+                  snapCount \n The default value is 100,000"
+                type: integer
+              snapSizeLimitInKb:
+                description: "Snapshot size limit in Kb \n The defult value is 4GB"
+                type: integer
+              syncLimit:
+                description: "SyncLimit is the amount of time, in ticks, to allow
+                  followers to sync with Zookeeper. \n The default value is 2."
+                type: integer
+              tickTime:
+                description: "TickTime is the length of a single tick, which is
+                  the basic time unit used by Zookeeper, as measured in milliseconds
+                  \n The default value is 2000."
+                type: integer
               type: object
             containers:
               description: Containers defines to support multi containers

--- a/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -69,10 +69,47 @@ spec:
                 is provided required default values will be provided, and optional
                 values will be excluded.
               properties:
+                commitLogCount:
+                  description: "Zookeeper maintains an in-memory list of last committed
+                    requests for fast synchronization with followers \n The default
+                    value is 500"
+                  type: integer
+                globalOutstandingLimit:
+                  description: "Clients can submit requests faster than ZooKeeper
+                    can process them, especially if there are a lot of clients. Zookeeper
+                    will throttle Clients so that requests won't exceed global outstanding
+                    limit. \n The default value is 1000"
+                  type: integer
                 initLimit:
                   description: "InitLimit is the amount of time, in ticks, to allow
                     followers to connect and sync to a leader. \n Default value is
                     10."
+                  type: integer
+                maxClientCnxns:
+                  description: "Limits the number of concurrent connections that a
+                    single client, identified by IP address, may make to a single
+                    member of the ZooKeeper ensemble. \n The default value is 60"
+                  type: integer
+                maxCnxns:
+                  description: "Limits the total number of concurrent connections
+                    that can be made to a zookeeper server \n The defult value is
+                    0, indicating no limit"
+                  type: integer
+                maxSessionTimeout:
+                  description: "the maximum session timeout in milliseconds that the
+                    server will allow the client to negotiate. \n The default value
+                    is 40000"
+                  type: integer
+                minSessionTimeout:
+                  type: integer
+                preAllocSize:
+                  description: "To avoid seeks ZooKeeper allocates space in the transaction
+                    log file in blocks of preAllocSize kilobytes \n The default value
+                    is 64M"
+                  type: integer
+                purgeInterval:
+                  description: "The time interval in hours for which the purge task
+                    has to be triggered \n Disabled by default"
                   type: integer
                 quorumListenOnAllIPs:
                   description: "QuorumListenOnAllIPs when set to true the ZooKeeper
@@ -82,6 +119,19 @@ spec:
                     the ZAB protocol and the Fast Leader Election protocol. \n The
                     default value is false."
                   type: boolean
+                snapCount:
+                  description: "ZooKeeper records its transactions using snapshots
+                    and a transaction log The number of transactions recorded in the
+                    transaction log before a snapshot can be taken is determined by
+                    snapCount \n The default value is 100,000"
+                  type: integer
+                snapRetainCount:
+                  description: "Retain the snapshots according to retain count \n
+                    The default valueis 3"
+                  type: integer
+                snapSizeLimitInKb:
+                  description: "Snapshot size limit \n The defult value is 4GB"
+                  type: integer
                 syncLimit:
                   description: "SyncLimit is the amount of time, in ticks, to allow
                     followers to sync with Zookeeper. \n The default value is 2."

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -63,7 +63,7 @@ The following table lists the configurable parameters of the zookeeper chart and
 | `ports` | Groups the ports for a zookeeper cluster node for easy access | `[]` |
 | `pod` | Defines the policy to create new pods for the zookeeper cluster | `{}` |
 | `pod.labels` | Labels to attach to the pods | `{}` |
-| `pod.nodeSelector` | Map of key-value pairs to be present as labels in the node in which the pod should run | `{}` |
+| `pod.nodeSelector` | Map of key-value pairs to be present as labels in the node in which the pod shoul`6553d run | `{}` |
 | `pod.affinity` | Specifies scheduling constraints on pods | `{}` |
 | `pod.resources` | Specifies resource requirements for the container | `{}` |
 | `pod.tolerations` | Specifies the pod's tolerations | `[]` |
@@ -75,6 +75,17 @@ The following table lists the configurable parameters of the zookeeper chart and
 | `config.initLimit` | Amount of time (in ticks) to allow followers to connect and sync to a leader | `10` |
 | `config.tickTime` | Length of a single tick which is the basic time unit used by Zookeeper (measured in milliseconds) | `2000` |
 | `config.syncLimit` | Amount of time (in ticks) to allow followers to sync with Zookeeper | `2` |
+| `config.globalOutstandingLimit` | Max limit for outstanding requests | `1000` |
+| `config.preAllocSize` | PreAllocSize in kilobytes | `65536` |
+| `config.snapCount` | The number of transactions recorded in the transaction log before a snapshot can be taken | `100000` |
+| `config.commitLogCount` | The number of committed requests in memory | `500`
+| `config.snapSizeLimitInKb` | SnapSizeLimitInKb | `4194304` |
+| `config.maxCnxns` | The total number of concurrent connections that can be made to a zookeeper server | `0` |
+| `config.maxClientCnxns` | The number of concurrent connections that a single client | `60` |
+| `config.minSessionTimeout` | The minimum session timeout in milliseconds that the server will allow the client to negotiate | `4000` |
+| `config.maxSessionTimeout` | The maximum session timeout in milliseconds that the server will allow the client to negotiate | `40000` |
+| `config.autoPurgeSnapRetainCount` | The number of snapshots to be retained | `3`
+| `config.autoPurgePurgeInterval` | The time interval in hours for which the purge task has to be triggered | `0`
 | `config.quorumListenOnAllIPs` | Whether Zookeeper server will listen for connections from its peers on all available IP addresses | `false` |
 | `storageType` | Type of storage that can be used it can take either ephemeral or persistence as value | `persistence` |
 | `persistence.reclaimPolicy` | Reclaim policy for persistent volumes | `Delete` |

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -63,7 +63,7 @@ The following table lists the configurable parameters of the zookeeper chart and
 | `ports` | Groups the ports for a zookeeper cluster node for easy access | `[]` |
 | `pod` | Defines the policy to create new pods for the zookeeper cluster | `{}` |
 | `pod.labels` | Labels to attach to the pods | `{}` |
-| `pod.nodeSelector` | Map of key-value pairs to be present as labels in the node in which the pod shoul`6553d run | `{}` |
+| `pod.nodeSelector` | Map of key-value pairs to be present as labels in the node in which the pod should run | `{}` |
 | `pod.affinity` | Specifies scheduling constraints on pods | `{}` |
 | `pod.resources` | Specifies resource requirements for the container | `{}` |
 | `pod.tolerations` | Specifies the pod's tolerations | `[]` |

--- a/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -68,6 +68,14 @@ spec:
                 is provided required default values will be provided, and optional
                 values will be excluded.
               properties:
+                autoPurgePurgeInterval:
+                  description: "The time interval in hours for which the purge task
+                    has to be triggered \n Disabled by default"
+                  type: integer
+                autoPurgeSnapRetainCount:
+                  description: "Retain the snapshots according to retain count \n
+                    The default value is 3"
+                  type: integer
                 commitLogCount:
                   description: "Zookeeper maintains an in-memory list of last committed
                     requests for fast synchronization with followers \n The default
@@ -95,20 +103,19 @@ spec:
                     0, indicating no limit"
                   type: integer
                 maxSessionTimeout:
-                  description: "the maximum session timeout in milliseconds that the
+                  description: "The maximum session timeout in milliseconds that the
                     server will allow the client to negotiate. \n The default value
                     is 40000"
                   type: integer
                 minSessionTimeout:
+                  description: "The minimum session timeout in milliseconds that the
+                    server will allow the client to negotiate \n The default value
+                    is 4000"
                   type: integer
                 preAllocSize:
                   description: "To avoid seeks ZooKeeper allocates space in the transaction
                     log file in blocks of preAllocSize kilobytes \n The default value
                     is 64M"
-                  type: integer
-                purgeInterval:
-                  description: "The time interval in hours for which the purge task
-                    has to be triggered \n Disabled by default"
                   type: integer
                 quorumListenOnAllIPs:
                   description: "QuorumListenOnAllIPs when set to true the ZooKeeper
@@ -124,12 +131,8 @@ spec:
                     transaction log before a snapshot can be taken is determined by
                     snapCount \n The default value is 100,000"
                   type: integer
-                snapRetainCount:
-                  description: "Retain the snapshots according to retain count \n
-                    The default valueis 3"
-                  type: integer
                 snapSizeLimitInKb:
-                  description: "Snapshot size limit \n The defult value is 4GB"
+                  description: "Snapshot size limit in Kb \n The defult value is 4GB"
                   type: integer
                 syncLimit:
                   description: "SyncLimit is the amount of time, in ticks, to allow
@@ -685,9 +688,7 @@ spec:
                     type: array
                     x-kubernetes-list-map-keys:
                     - containerPort
-                    {{- if semverCompare "< 1.18-0" .Capabilities.KubeVersion.GitVersion }}
                     - protocol
-                    {{- end }}
                     x-kubernetes-list-type: map
                   readinessProbe:
                     description: 'Periodic probe of container service readiness. Container
@@ -1276,10 +1277,6 @@ spec:
                       description: 'AccessModes contains the desired access modes
                         the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                       items:
-                        enum:
-                        - ReadWriteOnce
-                        - ReadOnlyMany
-                        - ReadWriteMany
                         type: string
                       type: array
                     dataSource:
@@ -1356,11 +1353,6 @@ spec:
                                 description: operator represents a key's relationship
                                   to a set of values. Valid operators are In, NotIn,
                                   Exists and DoesNotExist.
-                                enum:
-                                - In
-                                - NotIn
-                                - Exists
-                                - DoesNotExist
                                 type: string
                               values:
                                 description: values is an array of string values.
@@ -1451,13 +1443,6 @@ spec:
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
-                                          enum:
-                                          - In
-                                          - NotIn
-                                          - Exists
-                                          - DoesNotExist
-                                          - Gt
-                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -1494,13 +1479,6 @@ spec:
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
-                                          enum:
-                                          - In
-                                          - NotIn
-                                          - Exists
-                                          - DoesNotExist
-                                          - Gt
-                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -1566,13 +1544,6 @@ spec:
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
-                                          enum:
-                                          - In
-                                          - NotIn
-                                          - Exists
-                                          - DoesNotExist
-                                          - Gt
-                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -1609,13 +1580,6 @@ spec:
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
-                                          enum:
-                                          - In
-                                          - NotIn
-                                          - Exists
-                                          - DoesNotExist
-                                          - Gt
-                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -1689,11 +1653,6 @@ spec:
                                                 relationship to a set of values. Valid
                                                 operators are In, NotIn, Exists and
                                                 DoesNotExist.
-                                              enum:
-                                              - In
-                                              - NotIn
-                                              - Exists
-                                              - DoesNotExist
                                               type: string
                                             values:
                                               description: values is an array of string
@@ -1792,11 +1751,6 @@ spec:
                                           description: operator represents a key's
                                             relationship to a set of values. Valid
                                             operators are In, NotIn, Exists and DoesNotExist.
-                                          enum:
-                                          - In
-                                          - NotIn
-                                          - Exists
-                                          - DoesNotExist
                                           type: string
                                         values:
                                           description: values is an array of string
@@ -1895,11 +1849,6 @@ spec:
                                                 relationship to a set of values. Valid
                                                 operators are In, NotIn, Exists and
                                                 DoesNotExist.
-                                              enum:
-                                              - In
-                                              - NotIn
-                                              - Exists
-                                              - DoesNotExist
                                               type: string
                                             values:
                                               description: values is an array of string
@@ -1998,11 +1947,6 @@ spec:
                                           description: operator represents a key's
                                             relationship to a set of values. Valid
                                             operators are In, NotIn, Exists and DoesNotExist.
-                                          enum:
-                                          - In
-                                          - NotIn
-                                          - Exists
-                                          - DoesNotExist
                                           type: string
                                         values:
                                           description: values is an array of string
@@ -2385,8 +2329,6 @@ spec:
                     description: Number of port to expose on the pod's IP address.
                       This must be a valid port number, 0 < x < 65536.
                     format: int32
-                    minimum: 1
-                    maximum: 65535
                     type: integer
                   hostIP:
                     description: What host IP to bind the external port to.
@@ -2397,8 +2339,6 @@ spec:
                       is specified, this must match ContainerPort. Most containers
                       do not need this.
                     format: int32
-                    minimum: 1
-                    maximum: 65535
                     type: integer
                   name:
                     description: If specified, this must be an IANA_SVC_NAME and unique
@@ -2408,10 +2348,6 @@ spec:
                   protocol:
                     description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults
                       to "TCP".
-                    enum:
-                    - UDP
-                    - TCP
-                    - SCTP
                     type: string
                 required:
                 - containerPort
@@ -2429,9 +2365,6 @@ spec:
               description: StorageType is used to tell which type of storage we will
                 be using It can take either Ephemeral or persistence Default StorageType
                 is Persistence storage
-              enum:
-              - ephemeral
-              - persistence
               type: string
             volumes:
               description: Volumes defines to support customized volumes

--- a/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -68,10 +68,47 @@ spec:
                 is provided required default values will be provided, and optional
                 values will be excluded.
               properties:
+                commitLogCount:
+                  description: "Zookeeper maintains an in-memory list of last committed
+                    requests for fast synchronization with followers \n The default
+                    value is 500"
+                  type: integer
+                globalOutstandingLimit:
+                  description: "Clients can submit requests faster than ZooKeeper
+                    can process them, especially if there are a lot of clients. Zookeeper
+                    will throttle Clients so that requests won't exceed global outstanding
+                    limit. \n The default value is 1000"
+                  type: integer
                 initLimit:
                   description: "InitLimit is the amount of time, in ticks, to allow
                     followers to connect and sync to a leader. \n Default value is
                     10."
+                  type: integer
+                maxClientCnxns:
+                  description: "Limits the number of concurrent connections that a
+                    single client, identified by IP address, may make to a single
+                    member of the ZooKeeper ensemble. \n The default value is 60"
+                  type: integer
+                maxCnxns:
+                  description: "Limits the total number of concurrent connections
+                    that can be made to a zookeeper server \n The defult value is
+                    0, indicating no limit"
+                  type: integer
+                maxSessionTimeout:
+                  description: "the maximum session timeout in milliseconds that the
+                    server will allow the client to negotiate. \n The default value
+                    is 40000"
+                  type: integer
+                minSessionTimeout:
+                  type: integer
+                preAllocSize:
+                  description: "To avoid seeks ZooKeeper allocates space in the transaction
+                    log file in blocks of preAllocSize kilobytes \n The default value
+                    is 64M"
+                  type: integer
+                purgeInterval:
+                  description: "The time interval in hours for which the purge task
+                    has to be triggered \n Disabled by default"
                   type: integer
                 quorumListenOnAllIPs:
                   description: "QuorumListenOnAllIPs when set to true the ZooKeeper
@@ -81,6 +118,19 @@ spec:
                     the ZAB protocol and the Fast Leader Election protocol. \n The
                     default value is false."
                   type: boolean
+                snapCount:
+                  description: "ZooKeeper records its transactions using snapshots
+                    and a transaction log The number of transactions recorded in the
+                    transaction log before a snapshot can be taken is determined by
+                    snapCount \n The default value is 100,000"
+                  type: integer
+                snapRetainCount:
+                  description: "Retain the snapshots according to retain count \n
+                    The default valueis 3"
+                  type: integer
+                snapSizeLimitInKb:
+                  description: "Snapshot size limit \n The defult value is 4GB"
+                  type: integer
                 syncLimit:
                   description: "SyncLimit is the amount of time, in ticks, to allow
                     followers to sync with Zookeeper. \n The default value is 2."
@@ -635,6 +685,9 @@ spec:
                     type: array
                     x-kubernetes-list-map-keys:
                     - containerPort
+                    {{- if semverCompare "< 1.18-0" .Capabilities.KubeVersion.GitVersion }}
+                    - protocol
+                    {{- end }}
                     x-kubernetes-list-type: map
                   readinessProbe:
                     description: 'Periodic probe of container service readiness. Container

--- a/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -688,7 +688,6 @@ spec:
                     type: array
                     x-kubernetes-list-map-keys:
                     - containerPort
-                    - protocol
                     x-kubernetes-list-type: map
                   readinessProbe:
                     description: 'Periodic probe of container service readiness. Container
@@ -1277,6 +1276,10 @@ spec:
                       description: 'AccessModes contains the desired access modes
                         the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                       items:
+                        enum:
+                        - ReadWriteOnce
+                        - ReadOnlyMany
+                        - ReadWriteMany
                         type: string
                       type: array
                     dataSource:
@@ -1353,6 +1356,11 @@ spec:
                                 description: operator represents a key's relationship
                                   to a set of values. Valid operators are In, NotIn,
                                   Exists and DoesNotExist.
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
                                 type: string
                               values:
                                 description: values is an array of string values.
@@ -1443,6 +1451,13 @@ spec:
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          - Gt
+                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -1479,6 +1494,13 @@ spec:
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          - Gt
+                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -1544,6 +1566,13 @@ spec:
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          - Gt
+                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -1580,6 +1609,13 @@ spec:
                                             to a set of values. Valid operators are
                                             In, NotIn, Exists, DoesNotExist. Gt, and
                                             Lt.
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          - Gt
+                                          - Lt
                                           type: string
                                         values:
                                           description: An array of string values.
@@ -1653,6 +1689,11 @@ spec:
                                                 relationship to a set of values. Valid
                                                 operators are In, NotIn, Exists and
                                                 DoesNotExist.
+                                              enum:
+                                              - In
+                                              - NotIn
+                                              - Exists
+                                              - DoesNotExist
                                               type: string
                                             values:
                                               description: values is an array of string
@@ -1751,6 +1792,11 @@ spec:
                                           description: operator represents a key's
                                             relationship to a set of values. Valid
                                             operators are In, NotIn, Exists and DoesNotExist.
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
                                           type: string
                                         values:
                                           description: values is an array of string
@@ -1849,6 +1895,11 @@ spec:
                                                 relationship to a set of values. Valid
                                                 operators are In, NotIn, Exists and
                                                 DoesNotExist.
+                                              enum:
+                                              - In
+                                              - NotIn
+                                              - Exists
+                                              - DoesNotExist
                                               type: string
                                             values:
                                               description: values is an array of string
@@ -1947,6 +1998,11 @@ spec:
                                           description: operator represents a key's
                                             relationship to a set of values. Valid
                                             operators are In, NotIn, Exists and DoesNotExist.
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
                                           type: string
                                         values:
                                           description: values is an array of string
@@ -2329,6 +2385,8 @@ spec:
                     description: Number of port to expose on the pod's IP address.
                       This must be a valid port number, 0 < x < 65536.
                     format: int32
+                    minimum: 1
+                    maximum: 65535
                     type: integer
                   hostIP:
                     description: What host IP to bind the external port to.
@@ -2339,6 +2397,8 @@ spec:
                       is specified, this must match ContainerPort. Most containers
                       do not need this.
                     format: int32
+                    minimum: 1
+                    maximum: 65535
                     type: integer
                   name:
                     description: If specified, this must be an IANA_SVC_NAME and unique
@@ -2348,6 +2408,10 @@ spec:
                   protocol:
                     description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults
                       to "TCP".
+                    enum:
+                    - UDP
+                    - TCP
+                    - SCTP
                     type: string
                 required:
                 - containerPort
@@ -2365,6 +2429,9 @@ spec:
               description: StorageType is used to tell which type of storage we will
                 be using It can take either Ephemeral or persistence Default StorageType
                 is Persistence storage
+              enum:
+              - ephemeral
+              - persistence
               type: string
             volumes:
               description: Volumes defines to support customized volumes

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	k8s.io/api v0.17.5
 	k8s.io/apimachinery v0.17.5
 	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/code-generator v0.19.3 // indirect
 	sigs.k8s.io/controller-runtime v0.5.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1137,10 +1137,12 @@ k8s.io/autoscaler v0.0.0-20190607113959-1b4f1855cb8e/go.mod h1:QEXezc9uKPT91dwqh
 k8s.io/cli-runtime v0.17.5/go.mod h1:MgU0RZdbJoDThMLacP4ik4W7qpI0wOf2uiMyzVvB/BE=
 k8s.io/client-go v0.17.5 h1:Sm/9AQ415xPAX42JLKbJZnreXFgD2rVfDUDwOTm0gzA=
 k8s.io/client-go v0.17.5/go.mod h1:S8uZpBpjJJdEH/fEyxcqg7Rn0P5jH+ilkgBHjriSmNo=
+k8s.io/code-generator v0.17.6-beta.0 h1:1TWQ5C1MpYdLLs/xQwqRYuPAe26IitM6n3bqsj0QjFc=
 k8s.io/code-generator v0.17.6-beta.0/go.mod h1:qdiSCSTKtS+3WtPelj2h57fylSQcPUlhMVm+TD9Dvqc=
 k8s.io/component-base v0.17.5/go.mod h1:cZQAW1AUbBjD1lh+e/krbiIpqGz6fipI+vHslOBbuHE=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20191010091904-7fa3014cb28f h1:eW/6wVuHNZgQJmFesyAxu0cvj0WAHHUuGaLbPcmNY3Q=
 k8s.io/gengo v0.0.0-20191010091904-7fa3014cb28f/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/helm v2.16.3+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -438,7 +438,7 @@ type ZookeeperConfig struct {
 	// The default value is 500
 	CommitLogCount int `json:"commitLogCount,omitempty"`
 
-	// SnapSizeLimitInKb
+	// Snapshot size limit in Kb
 	//
 	// The defult value is 4GB
 	SnapSizeLimitInKb int `json:"snapSizeLimitInKb,omitempty"`
@@ -459,7 +459,6 @@ type ZookeeperConfig struct {
 	// client to negotiate
 	//
 	// The default value is 4000
-
 	MinSessionTimeout int `json:"minSessionTimeout,omitempty"`
 
 	// The maximum session timeout in milliseconds that the server will allow the
@@ -470,7 +469,7 @@ type ZookeeperConfig struct {
 
 	// Retain the snapshots according to retain count
 	//
-	// The default valueis 3
+	// The default value is 3
 	AutoPurgeSnapRetainCount int `json:"autoPurgeSnapRetainCount,omitempty"`
 
 	// The time interval in hours for which the purge task has to be triggered

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -68,9 +68,11 @@ type ZookeeperClusterSpec struct {
 	//It can take either Ephemeral or persistence
 	//Default StorageType is Persistence storage
 	StorageType string `json:"storageType,omitempty"`
+
 	// Persistence is the configuration for zookeeper persistent layer.
 	// PersistentVolumeClaimSpec and VolumeReclaimPolicy can be specified in here.
 	Persistence *Persistence `json:"persistence,omitempty"`
+
 	// Ephemeral is the configuration which helps create ephemeral storage
 	// At anypoint only one of Persistence or Ephemeral should be present in the manifest
 	Ephemeral *Ephemeral `json:"ephemeral,omitempty"`
@@ -527,7 +529,7 @@ func (c *ZookeeperConfig) withDefaults() (changed bool) {
 		changed = true
 		c.MinSessionTimeout = 2 * c.TickTime
 	}
-	if c.MinSessionTimeout == 0 {
+	if c.MaxSessionTimeout == 0 {
 		changed = true
 		c.MaxSessionTimeout = 20 * c.TickTime
 	}

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -194,9 +194,6 @@ func (s *ZookeeperClusterSpec) withDefaults(z *ZookeeperCluster) (changed bool) 
 	return changed
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +k8s:openapi-gen=true
-
 // Generate CRD using kubebuilder
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
@@ -208,6 +205,8 @@ func (s *ZookeeperClusterSpec) withDefaults(z *ZookeeperCluster) (changed bool) 
 // +kubebuilder:printcolumn:name="Internal Endpoint",type=string,JSONPath=`.status.internalClientEndpoint`,description="Client endpoint internal to cluster network"
 // +kubebuilder:printcolumn:name="External Endpoint",type=string,JSONPath=`.status.externalClientEndpoint`,description="Client endpoint external to cluster network via LoadBalancer"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +k8s:openapi-gen=true
 
 // ZookeeperCluster is the Schema for the zookeeperclusters API
 type ZookeeperCluster struct {
@@ -413,6 +412,72 @@ type ZookeeperConfig struct {
 	// The default value is 2.
 	SyncLimit int `json:"syncLimit,omitempty"`
 
+	// Clients can submit requests faster than ZooKeeper can process them, especially
+	// if there are a lot of clients. Zookeeper will throttle Clients so that requests
+	// won't exceed global outstanding limit.
+	//
+	// The default value is 1000
+	GlobalOutstandingLimit int `json:"globalOutstandingLimit,omitempty"`
+
+	// To avoid seeks ZooKeeper allocates space in the transaction log file in
+	// blocks of preAllocSize kilobytes
+	//
+	// The default value is 64M
+	PreAllocSize int `json:"preAllocSize,omitempty"`
+
+	// ZooKeeper records its transactions using snapshots and a transaction log
+	// The number of transactions recorded in the transaction log before a snapshot
+	// can be taken is determined by snapCount
+	//
+	// The default value is 100,000
+	SnapCount int `json:"snapCount,omitempty"`
+
+	// Zookeeper maintains an in-memory list of last committed requests for fast
+	// synchronization with followers
+	//
+	// The default value is 500
+	CommitLogCount int `json:"commitLogCount,omitempty"`
+
+	// SnapSizeLimitInKb
+	//
+	// The defult value is 4GB
+	SnapSizeLimitInKb int `json:"snapSizeLimitInKb,omitempty"`
+
+	// Limits the total number of concurrent connections that can be made to a
+	//zookeeper server
+	//
+	// The defult value is 0, indicating no limit
+	MaxCnxns int `json:"maxCnxns,omitempty"`
+
+	// Limits the number of concurrent connections that a single client, identified
+	// by IP address, may make to a single member of the ZooKeeper ensemble.
+	//
+	// The default value is 60
+	MaxClientCnxns int `json:"maxClientCnxns,omitempty"`
+
+	// The minimum session timeout in milliseconds that the server will allow the
+	// client to negotiate
+	//
+	// The default value is 4000
+
+	MinSessionTimeout int `json:"minSessionTimeout,omitempty"`
+
+	// The maximum session timeout in milliseconds that the server will allow the
+	// client to negotiate.
+	//
+	// The default value is 40000
+	MaxSessionTimeout int `json:"maxSessionTimeout,omitempty"`
+
+	// Retain the snapshots according to retain count
+	//
+	// The default valueis 3
+	AutoPurgeSnapRetainCount int `json:"autoPurgeSnapRetainCount,omitempty"`
+
+	// The time interval in hours for which the purge task has to be triggered
+	//
+	// Disabled by default
+	AutoPurgePurgeInterval int `json:"autoPurgePurgeInterval,omitempty"`
+
 	// QuorumListenOnAllIPs when set to true the ZooKeeper server will listen for
 	// connections from its peers on all available IP addresses, and not only the
 	// address configured in the server list of the configuration file. It affects
@@ -435,6 +500,43 @@ func (c *ZookeeperConfig) withDefaults() (changed bool) {
 		changed = true
 		c.SyncLimit = 2
 	}
+	if c.GlobalOutstandingLimit == 0 {
+		changed = true
+		c.GlobalOutstandingLimit = 1000
+	}
+	if c.PreAllocSize == 0 {
+		changed = true
+		c.PreAllocSize = 65536
+	}
+	if c.SnapCount == 0 {
+		changed = true
+		c.SnapCount = 10000
+	}
+	if c.CommitLogCount == 0 {
+		changed = true
+		c.CommitLogCount = 500
+	}
+	if c.SnapSizeLimitInKb == 0 {
+		changed = true
+		c.SnapSizeLimitInKb = 4194304
+	}
+	if c.MaxClientCnxns == 0 {
+		changed = true
+		c.MaxClientCnxns = 60
+	}
+	if c.MinSessionTimeout == 0 {
+		changed = true
+		c.MinSessionTimeout = 2 * c.TickTime
+	}
+	if c.MinSessionTimeout == 0 {
+		changed = true
+		c.MaxSessionTimeout = 20 * c.TickTime
+	}
+	if c.AutoPurgeSnapRetainCount == 0 {
+		changed = true
+		c.AutoPurgeSnapRetainCount = 3
+	}
+
 	return changed
 }
 

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -232,6 +232,17 @@ func makeZkConfigString(s v1beta1.ZookeeperClusterSpec) string {
 		"initLimit=" + strconv.Itoa(s.Conf.InitLimit) + "\n" +
 		"syncLimit=" + strconv.Itoa(s.Conf.SyncLimit) + "\n" +
 		"tickTime=" + strconv.Itoa(s.Conf.TickTime) + "\n" +
+		"globalOutstandingLimit=" + strconv.Itoa(s.Conf.GlobalOutstandingLimit) + "\n" +
+		"preAllocSize=" + strconv.Itoa(s.Conf.PreAllocSize) + "\n" +
+		"snapCount=" + strconv.Itoa(s.Conf.SnapCount) + "\n" +
+		"commitLogCount=" + strconv.Itoa(s.Conf.CommitLogCount) + "\n" +
+		"snapSizeLimitInKb=" + strconv.Itoa(s.Conf.SnapSizeLimitInKb) + "\n" +
+		"maxCnxns=" + strconv.Itoa(s.Conf.MaxCnxns) + "\n" +
+		"maxClientCnxns=" + strconv.Itoa(s.Conf.MaxClientCnxns) + "\n" +
+		"minSessionTimeout=" + strconv.Itoa(s.Conf.MinSessionTimeout) + "\n" +
+		"maxSessionTimeout=" + strconv.Itoa(s.Conf.MaxSessionTimeout) + "\n" +
+		"autopurge.snapRetainCount=" + strconv.Itoa(s.Conf.AutoPurgeSnapRetainCount) + "\n" +
+		"autopurge.purgeInterval=" + strconv.Itoa(s.Conf.AutoPurgePurgeInterval) + "\n" +
 		"quorumListenOnAllIPs=" + strconv.FormatBool(s.Conf.QuorumListenOnAllIPs) + "\n" +
 		"dynamicConfigFile=/data/zoo.cfg.dynamic\n"
 }


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description
Added more zookeeper configuration options in zookeeper configmap.

### Purpose of the change

Fixes #220, #224 

### What the code does

Added more options as part of zookeeper spec under config, so that users are able to configure these values
### How to verify it

Able to set the configuration options, and pod should come up with the values set.
