### PR TITLE
Issue 263: Delete the old transaction logs from zookeeper

### DIFF
--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -9,7 +9,7 @@ global:
 
 image:
   repository: pravega/zookeeper-operator
-  tag: 0.2.8
+  tag: 0.2.9
   pullPolicy: IfNotPresent
 
 ## Install RBAC roles and bindings.

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -85,7 +85,7 @@ The following table lists the configurable parameters of the zookeeper chart and
 | `config.minSessionTimeout` | The minimum session timeout in milliseconds that the server will allow the client to negotiate | `4000` |
 | `config.maxSessionTimeout` | The maximum session timeout in milliseconds that the server will allow the client to negotiate | `40000` |
 | `config.autoPurgeSnapRetainCount` | The number of snapshots to be retained | `3`
-| `config.autoPurgePurgeInterval` | The time interval in hours for which the purge task has to be triggered | `0`
+| `config.autoPurgePurgeInterval` | The time interval in hours for which the purge task has to be triggered | `1`
 | `config.quorumListenOnAllIPs` | Whether Zookeeper server will listen for connections from its peers on all available IP addresses | `false` |
 | `storageType` | Type of storage that can be used it can take either ephemeral or persistence as value | `persistence` |
 | `persistence.reclaimPolicy` | Reclaim policy for persistent volumes | `Delete` |

--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -75,6 +75,39 @@ spec:
     {{- if .Values.config.syncLimit }}
     syncLimit: {{ .Values.config.syncLimit }}
     {{- end }}
+    {{- if .Values.config.globalOutstandingLimit }}
+    globalOutstandingLimit: {{ .Values.config.globalOutstandingLimit }}
+    {{- end }}
+    {{- if .Values.config.preAllocSize }}
+    preAllocSize: {{ .Values.config.preAllocSize }}
+    {{- end }}
+    {{- if .Values.config.snapCount }}
+    snapCount: {{ .Values.config.snapCount }}
+    {{- end }}
+    {{- if .Values.config.commitLogCount }}
+    commitLogCount: {{ .Values.config.commitLogCount }}
+    {{- end }}
+    {{- if .Values.config.snapSizeLimitInKb }}
+    snapSizeLimitInKb: {{ .Values.snapSizeLimitInKb }}
+    {{- end }}
+    {{- if .Values.config.maxCnxns }}
+    maxCnxns: {{ .Values.maxCnxns }}
+    {{- end }}
+    {{- if .Values.config.maxClientCnxns }}
+    maxClientCnxns: {{ .Values.maxClientCnxns }}
+    {{- end }}
+    {{- if .Values.config.minSessionTimeout }}
+    minSessionTimeout: {{ .Values.minSessionTimeout }}
+    {{- end }}
+    {{- if .Values.config.maxSessionTimeout }}
+    maxSessionTimeout: {{ .Values.maxSessionTimeout }}
+    {{- end }}
+    {{- if .Values.config.autoPurgeSnapRetainCount }}
+    autoPurgeSnapRetainCount: {{ .Values.autoPurgeSnapRetainCount }}
+    {{- end }}
+    {{- if .Values.config.autoPurgePurgeInterval }}
+    autoPurgePurgeInterval: {{ .Values.config.autoPurgePurgeInterval }}
+    {{- end }}
     {{- if .Values.config.quorumListenOnAllIPs }}
     quorumListenOnAllIPs: {{ .Values.config.quorumListenOnAllIPs }}
     {{- end }}

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -2,7 +2,7 @@ replicas: 3
 
 image:
   repository: pravega/zookeeper
-  tag: 0.2.8
+  tag: 0.2.9
   pullPolicy: IfNotPresent
 
 domainName:
@@ -26,6 +26,17 @@ config: {}
   # initLimit: 10
   # tickTime: 2000
   # syncLimit: 2
+  # globalOutstandingLimit: 1000
+  # preAllocSize: 65536
+  # snapCount: 100000
+  # commitLogCount: 500
+  # snapSizeLimitInKb: 4194304
+  # maxCnxns: 0
+  # maxClientCnxns: 60
+  # minSessionTimeout: 4000
+  # maxSessionTimeout: 40000
+  # autoPurgeSnapRetainCount: 3
+  # autoPurgePurgeInterval: 1
   # quorumListenOnAllIPs: false
 
 ## configure the storage type

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -537,6 +537,10 @@ func (c *ZookeeperConfig) withDefaults() (changed bool) {
 		changed = true
 		c.AutoPurgeSnapRetainCount = 3
 	}
+	if c.AutoPurgePurgeInterval == 0 {
+		changed = true
+		c.AutoPurgePurgeInterval = 1
+	}
 
 	return changed
 }


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description
Delete the old transaction logs by setting autopurge.Inerval to 1 hr in zookeeper configuration
### Purpose of the change

Fixes #263

### What the code does

Set the default values of `autopurge.Inerval` to 1 hr. So that older snapshots got deleted automatically.

### How to verify it

Verified that Purge Interval is set correctly from the zookeeper logs and older snapshots are getting deleted.
