### PR TITLE
Issue-265-Helm chart version differs from pravega/charts

### DIFF
--- a/charts/zookeeper-operator/Chart.yaml
+++ b/charts/zookeeper-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: zookeeper-operator
 description: Zookeeper Operator Helm chart for Kubernetes
-version: 0.2.8
-appVersion: 0.2.8
+version: 0.2.9
+appVersion: 0.2.9
 keywords:
 - zookeeper
 - storage

--- a/charts/zookeeper-operator/README.md
+++ b/charts/zookeeper-operator/README.md
@@ -42,7 +42,7 @@ The following table lists the configurable parameters of the zookeeper-operator 
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
 | `image.repository` | Image repository | `pravega/zookeeper-operator` |
-| `image.tag` | Image tag | `0.2.8` |
+| `image.tag` | Image tag | `0.2.9` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `crd.create` | Create zookeeper CRD | `true` |
 | `rbac.create` | Create RBAC resources | `true` |

--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: zookeeper
 description: Zookeeper Helm chart for Kubernetes
-version: 0.2.8
-appVersion: 0.2.8
+version: 0.2.9
+appVersion: 0.2.9
 keywords:
 - zookeeper
 - storage

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -55,7 +55,7 @@ The following table lists the configurable parameters of the zookeeper chart and
 | ----- | ----------- | ------ |
 | `replicas` | Expected size of the zookeeper cluster (valid range is from 1 to 7) | `3` |
 | `image.repository` | Image repository | `pravega/zookeeper` |
-| `image.tag` | Image tag | `0.2.8` |
+| `image.tag` | Image tag | `0.2.9` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `domainName` | External host name appended for dns annotation | |
 | `kubernetesClusterDomain` | Domain of the kubernetes cluster | `cluster.local` |

--- a/deploy/all_ns/operator.yaml
+++ b/deploy/all_ns/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: zookeeper-operator
           # Replace this with the built image name
-          image: pravega/zookeeper-operator:0.2.8
+          image: pravega/zookeeper-operator:0.2.9
           ports:
           - containerPort: 60000
             name: metrics

--- a/deploy/cr/ECS/zookeeper_v1beta1_zookeepercluster_cr.yaml
+++ b/deploy/cr/ECS/zookeeper_v1beta1_zookeepercluster_cr.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 3
   image:
     repository: pravega/zookeeper
-    tag: 0.2.8
+    tag: 0.2.9
   storageType: persistence
   persistence:
     reclaimPolicy: Retain

--- a/deploy/cr/pravega/zookeeper_v1beta1_zookeepercluster_cr.yaml
+++ b/deploy/cr/pravega/zookeeper_v1beta1_zookeepercluster_cr.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 3
   image:
     repository: pravega/zookeeper
-    tag: 0.2.8
+    tag: 0.2.9
   storageType: persistence
   persistence:
     reclaimPolicy: Delete

--- a/deploy/default_ns/operator.yaml
+++ b/deploy/default_ns/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: zookeeper-operator
           # Replace this with the built image name
-          image: pravega/zookeeper-operator:0.2.8
+          image: pravega/zookeeper-operator:0.2.9
           ports:
           - containerPort: 60000
             name: metrics

--- a/test/e2e/multiple_zk_test.go
+++ b/test/e2e/multiple_zk_test.go
@@ -58,7 +58,7 @@ func testMultiZKCluster(t *testing.T) {
 	defaultCluster.Spec.Persistence.VolumeReclaimPolicy = "Delete"
 	defaultCluster.ObjectMeta.Name = "zk2"
 	initialVersion := "0.2.7"
-	upgradeVersion := "0.2.8-rc0"
+	upgradeVersion := "0.2.9"
 	defaultCluster.Spec.Image = api.ContainerImage{
 		Repository: "pravega/zookeeper",
 		Tag:        initialVersion,

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -40,7 +40,7 @@ func testUpgradeCluster(t *testing.T) {
 	cluster.Status.Init()
 	cluster.Spec.Persistence.VolumeReclaimPolicy = "Delete"
 	initialVersion := "0.2.7"
-	upgradeVersion := "0.2.8-rc0"
+	upgradeVersion := "0.2.9"
 	cluster.Spec.Image = api.ContainerImage{
 		Repository: "pravega/zookeeper",
 		Tag:        initialVersion,


### PR DESCRIPTION
Signed-off-by: prabhaker24 <prabhaker.saxena@dell.com>

### Change log description
Helm chart version differs from pravega/charts

### Purpose of the change
Fixes #265 
 
### What the code does
The ZooKeeper [operator] Helm charts provided in https://github.com/pravega/charts/tree/master/docs have recently been updated to version 0.2.9.
But the version in this repository is still 0.2.8:

https://github.com/pravega/zookeeper-operator/blob/master/charts/zookeeper/Chart.yaml
https://github.com/pravega/zookeeper-operator/blob/master/charts/zookeeper-operator/Chart.yaml

it fixes the version in both locations to 0.2.9 

### How to verify it
check both locations above in charts.yaml both has version set to 0.2.9.