### PR TITLE
Issue 269: Setting ephemeral storage type using charts

### DIFF
--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -1,3 +1,4 @@
+{{- $storageType := .Values.storageType | default "persistence" -}}
 apiVersion: "zookeeper.pravega.io/v1beta1"
 kind: "ZookeeperCluster"
 metadata:
@@ -112,16 +113,18 @@ spec:
     quorumListenOnAllIPs: {{ .Values.config.quorumListenOnAllIPs }}
     {{- end }}
   {{- end }}
-  storageType: {{ default "persistence" .Values.storageType }}
-  {{- if eq (default .Values.storageType "persistence") "ephemeral" }}
+  storageType: {{ $storageType }}
+  {{- if eq $storageType "ephemeral" }}
   ephemeral:
     {{- if .Values.ephemeral.emptydirvolumesource }}
     emptydirvolumesource:
+      {{- if .Values.ephemeral.emptydirvolumesource.medium }}
       medium: {{ .Values.ephemeral.emptydirvolumesource.medium }}
+      {{- end }}
       {{- if .Values.ephemeral.emptydirvolumesource.sizeLimit }}
       sizeLimit: {{ .Values.ephemeral.emptydirvolumesource.sizeLimit }}
       {{- end }}
-      {{- end }}
+    {{- end }}
   {{- else }}
   persistence:
     reclaimPolicy: {{ .Values.persistence.reclaimPolicy }}


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Currently even when the storageType is set to ephemeral within the values.yaml, theephemeral configuration is not taking effect and the storageType of the deployed zookeeper cluster is getting set to persistence instead of ephemeral. 

### Purpose of the change
Fixes #269 

### How to verify it
Tested the following use-cases :
- Deployed zookeeper operator 0.2.9 and zookeeper cluster 0.2.9 with storageType = ephemeral
- Deployed zookeeper operator 0.2.9 and zookeeper cluster 0.2.9 with storageType = persistence
- Deployed zookeeper operator 0.2.8 and zookeeper cluster 0.2.8, upgraded the zookeeper cluster to 0.2.9 using reuse-values
- Deployed zookeeper operator 0.2.9 and zookeeper cluster 0.2.8, upgraded the zookeeper cluster to 0.2.9 using reuse-values
- Deployed zookeeper operator 0.2.8 and zookeeper cluster 0.2.8, upgraded the zookeeper operator to 0.2.9 followed by upgrading the zookeeper cluster to 0.2.9 using reuse-values
- Deployed zookeeper operator 0.2.8 and zookeeper cluster 0.2.8, upgraded the zookeeper cluster to 0.2.9 using reuse-values followed by upgrading the zookeeper operator to 0.2.9