### PR TITLE
Issue 165: Adding annotations to PVC

### DIFF
--- a/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -1271,6 +1271,12 @@ spec:
                   - Delete
                   - Retain
                   type: string
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description: Annotations specifies the annotations to attach to
+                    pvc the operator creates.
+                  type: object
                 spec:
                   description: PersistentVolumeClaimSpec is the spec to describe PVC
                     for the container This field is optional. If no PVC is specified

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -89,6 +89,7 @@ The following table lists the configurable parameters of the zookeeper chart and
 | `config.quorumListenOnAllIPs` | Whether Zookeeper server will listen for connections from its peers on all available IP addresses | `false` |
 | `storageType` | Type of storage that can be used it can take either ephemeral or persistence as value | `persistence` |
 | `persistence.reclaimPolicy` | Reclaim policy for persistent volumes | `Delete` |
+| `persistence.annotations` | Specifies the annotations to attach to pvcs | `{}` |`
 | `persistence.storageClassName` | Storage class for persistent volumes | `` |
 | `persistence.volumeSize` | Size of the volume requested for persistent volumes | `20Gi` |
 | `ephemeral.emptydirvolumesource.medium` |  What type of storage medium should back the directory. | `""` |

--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -128,6 +128,10 @@ spec:
   {{- else }}
   persistence:
     reclaimPolicy: {{ .Values.persistence.reclaimPolicy }}
+    {{- if .Values.persistence.annotations }}
+    annotations:
+    {{ toYaml .Values.persistence.annotations | indent 6 }}
+    {{- end }}
     {{- if or .Values.persistence.storageClassName .Values.persistence.volumeSize }}
     spec:
       {{- if .Values.persistence.storageClassName }}

--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -130,7 +130,7 @@ spec:
     reclaimPolicy: {{ .Values.persistence.reclaimPolicy }}
     {{- if .Values.persistence.annotations }}
     annotations:
-    {{ toYaml .Values.persistence.annotations | indent 6 }}
+{{ toYaml .Values.persistence.annotations | indent 6 }}
     {{- end }}
     {{- if or .Values.persistence.storageClassName .Values.persistence.volumeSize }}
     spec:

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -49,6 +49,7 @@ persistence:
   ## specifying reclaim policy for PersistentVolumes
   ## accepted values - Delete / Retain
   reclaimPolicy: Delete
+  # annotations: {}
   volumeSize: 20Gi
 
 ephemeral:

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -49,7 +49,7 @@ persistence:
   ## specifying reclaim policy for PersistentVolumes
   ## accepted values - Delete / Retain
   reclaimPolicy: Delete
-  # annotations: {}
+  annotations: {}
   volumeSize: 20Gi
 
 ephemeral:

--- a/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -1267,6 +1267,12 @@ spec:
                   - Delete
                   - Retain
                   type: string
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description: Annotations specifies the annotations to attach to
+                    pvc the operator creates.
+                  type: object
                 spec:
                   description: PersistentVolumeClaimSpec is the spec to describe PVC
                     for the container This field is optional. If no PVC is specified

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,12 @@ module github.com/pravega/zookeeper-operator
 go 1.13
 
 require (
+	dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363 // indirect
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v0.1.0
+	github.com/gordonklaus/ineffassign v0.0.0-20201107091007-3b93a8888063 // indirect
 	github.com/mdempsky/maligned v0.0.0-20180708014732-6e39bd26a8c8 // indirect
+	github.com/mdempsky/unconvert v0.0.0-20200228143138-95ecdbfc0b5f // indirect
 	github.com/mibk/dupl v1.0.0 // indirect
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2k
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 cloud.google.com/go/storage v1.3.0/go.mod h1:9IAwXhoyBJ7z9LcAwkj0/7NnPzYaPeZxxVp3zm+5IqA=
 contrib.go.opencensus.io/exporter/ocagent v0.6.0/go.mod h1:zmKjrJcdo0aYcVS7bmEeSEBLPA9YJp5bjrofdU3pIXs=
+dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363 h1:o4lAkfETerCnr1kF9/qwkwjICnU+YLHNDCM8h2xj7as=
+dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363/go.mod h1:WG7q7swWsS2f9PYpt5DoEP/EBYWx8We5UoRltn9vJl8=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2/go.mod h1:4rQ/NZncSvGqNkkOsNpOU1tgoNuIlp9AfUH5G1tvCHc=
@@ -380,6 +382,8 @@ github.com/gophercloud/gophercloud v0.6.0 h1:Xb2lcqZtml1XjgYZxbeayEemq7ASbeTp09m
 github.com/gophercloud/gophercloud v0.6.0/go.mod h1:GICNByuaEBibcjmjvI7QvYJSZEbGkcYwAR7EZK2WMqM=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20191106031601-ce3c9ade29de/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gordonklaus/ineffassign v0.0.0-20201107091007-3b93a8888063 h1:dKprcOvlsvqfWn/iGvz+oYuC2axESeSMuF8dDrWMNsE=
+github.com/gordonklaus/ineffassign v0.0.0-20201107091007-3b93a8888063/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
@@ -533,6 +537,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/mdempsky/maligned v0.0.0-20180708014732-6e39bd26a8c8 h1:zvpKif6gkrh82wAd2JIffdLyCL52N8r+ABwHxdIOvWM=
 github.com/mdempsky/maligned v0.0.0-20180708014732-6e39bd26a8c8/go.mod h1:oGVD62YTpMEWw0JqJ2Vl48dzHywJBMlapkfsmhtokOU=
+github.com/mdempsky/unconvert v0.0.0-20200228143138-95ecdbfc0b5f h1:Kc3s6QFyh9DLgInXpWKuG+8I7R7lXbnP7mcoOVIt6KY=
+github.com/mdempsky/unconvert v0.0.0-20200228143138-95ecdbfc0b5f/go.mod h1:AmCV4WB3cDMZqgPk+OUQKumliiQS4ZYsBt3AXekyuAU=
 github.com/mibk/dupl v1.0.0 h1:aZc3jqrF9n0tUHwHt/+jsRxA8cRgA0Gdl56M7W7PoqE=
 github.com/mibk/dupl v1.0.0/go.mod h1:pCr4pNxxIbFGvtyCOi0c7LVjmV6duhKWV+ex5vh38ME=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -1019,6 +1025,7 @@ golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200115044656-831fdb1e1868/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200225230052-807dcd883420/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e h1:qCZ8SbsZMjT0OuDPCEBxgLZic4NMj8Gj4vNXiTVRAaA=
 golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200331202046-9d5940d49312 h1:2PHG+Ia3gK1K2kjxZnSylizb//eyaMG8gDFbOG7wLV8=

--- a/pkg/apis/zookeeper/v1beta1/deepcopy_test.go
+++ b/pkg/apis/zookeeper/v1beta1/deepcopy_test.go
@@ -86,6 +86,7 @@ var _ = Describe("ZookeeperCluster DeepCopy", func() {
 			z2.Spec.Ports[0].ContainerPort = p.ContainerPort
 			z1.SetAnnotations(m)
 			z2.Spec.Pod.Annotations = z1.Spec.Pod.Annotations
+			z1.Spec.Persistence.Annotations = m
 			z2.Spec.Persistence = z1.Spec.Persistence.DeepCopy()
 			z2.Spec.Ephemeral = z1.Spec.Ephemeral.DeepCopy()
 			z1.Spec.Pod.DeepCopyInto(&z2.Spec.Pod)

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -555,6 +555,9 @@ type Persistence struct {
 	// This field is optional. If no PVC is specified default persistentvolume
 	// will get created.
 	PersistentVolumeClaimSpec v1.PersistentVolumeClaimSpec `json:"spec,omitempty"`
+	// Annotations specifies the annotations to attach to pvc the operator
+	// creates.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 type Ephemeral struct {

--- a/pkg/apis/zookeeper/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/zookeeper/v1beta1/zz_generated.deepcopy.go
@@ -88,6 +88,13 @@ func (in *MembersStatus) DeepCopy() *MembersStatus {
 func (in *Persistence) DeepCopyInto(out *Persistence) {
 	*out = *in
 	in.PersistentVolumeClaimSpec.DeepCopyInto(&out.PersistentVolumeClaimSpec)
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -59,6 +59,7 @@ func MakeStatefulSet(z *v1beta1.ZookeeperCluster) *appsv1.StatefulSet {
 					z.Spec.Labels,
 					map[string]string{"app": z.GetName()},
 				),
+				Annotations: z.Spec.Persistence.Annotations,
 			},
 			Spec: persistence.PersistentVolumeClaimSpec,
 		})


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description
Added a new field annotations to persistence and populating while pvc is created

### Purpose of the change

 Fixes #165 

### What the code does

Provided support for adding annotations to PVCs
### How to verify it

Created zookeeper cluster, by specifying annotations in values.yaml file. Annotations are populated for PVC created
