### PR TITLE
Add support to add annotations to operator pod

### DIFF
--- a/charts/zookeeper-operator/templates/operator.yaml
+++ b/charts/zookeeper-operator/templates/operator.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         name: {{ template "zookeeper-operator.fullname" . }}
         component: zookeeper-operator
+      {{- if .Values.annotations }}
+      annotations:
+{{ toYaml .Values.annotations | indent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -46,6 +46,9 @@ nodeSelector: {}
 affinity: {}
 tolerations: []
 
+# Pod annotations
+annotations: {}
+
 hooks:
   backoffLimit: 10
   image:


### PR DESCRIPTION
### Change log description

Add support to add annotations to operator pod in helm chart

### Purpose of the change

Ability to set custom annotations to pods

### What the code does

Extends helm chart 

