### PR TITLE
Issue 291: Fixing post-install-upgrade hook

### DIFF
--- a/charts/zookeeper/templates/post-install-upgrade-hooks.yaml
+++ b/charts/zookeeper/templates/post-install-upgrade-hooks.yaml
@@ -63,7 +63,7 @@ data:
     set -e
     sleep 30
 
-    replicas=`kubectl get zk -n {{ .Release.Namespace }} {{ template "zookeeper.fullname" . }} -o jsonpath='{.status.replicas}'`
+    replicas=`kubectl get zk -n {{ .Release.Namespace }} {{ template "zookeeper.fullname" . }} -o jsonpath='{.spec.replicas}'`
     readyReplicas=`kubectl get zk -n {{ .Release.Namespace }} {{ template "zookeeper.fullname" . }} -o jsonpath='{.status.readyReplicas}'`
     currentVersion=`kubectl get zk -n {{ .Release.Namespace }} {{ template "zookeeper.fullname" . }} -o jsonpath='{.status.currentVersion}'`
     targetVersion=`kubectl get zk -n {{ .Release.Namespace }} {{ template "zookeeper.fullname" . }} -o jsonpath='{.spec.image.tag}'`


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
The post-install-upgrade hook in zookeeper cluster charts currently does not verify that all desired replicas have been deployed.

### Purpose of the change
Fixes #291 

### What the code does
The hook compares that the number of ready replicas is equal to the replica count mentioned within the spec, i.e. it checks that `.status.readyReplicas == .spec.replicas`

### How to verify it
The zookeeper cluster deployment should succeed only when all the desired replicas have come to ready state.
