### PR TITLE
Fixed zk image to run correctly on OpenShift

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,8 @@ RUN ./gradlew --console=verbose --info shadowJar
 FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}zookeeper:3.6.1
 COPY bin /usr/local/bin
 RUN chmod +x /usr/local/bin/*
-COPY --from=0 /zu/build/libs/zu.jar /root/
+COPY --from=0 /zu/build/libs/zu.jar /opt/zookeeper-libs/
 
 RUN apt-get -q update && \
-    apt-get install -y dnsutils curl procps
+    apt-get install -y --no-install-recommends dnsutils curl procps && \
+    apt-get purge && apt-get clean

--- a/docker/bin/zookeeperReady.sh
+++ b/docker/bin/zookeeperReady.sh
@@ -75,9 +75,9 @@ if [[ "$OK" == "imok" ]]; then
       ROLE=participant
       ZKURL=$(zkConnectionString)
       ZKCONFIG=$(zkConfig)
-      java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar remove $ZKURL $MYID
+      java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /opt/zookeeper-libs/zu.jar remove $ZKURL $MYID
       sleep 1
-      java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar add $ZKURL $MYID $ZKCONFIG
+      java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /opt/zookeeper-libs/zu.jar add $ZKURL $MYID $ZKCONFIG
       exit 0
     else
       echo "Something has gone wrong. Unable to determine zookeeper role."

--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -128,7 +128,7 @@ if [[ "$WRITE_CONFIGURATION" == true ]]; then
   else
     set -e
     ZKURL=$(zkConnectionString)
-    CONFIG=`java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar get-all $ZKURL`
+    CONFIG=`java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /opt/zookeeper-libs/zu.jar get-all $ZKURL`
     echo Writing configuration gleaned from zookeeper ensemble
     echo "$CONFIG" | grep -v "^version="> $DYNCONFIG
     set +e
@@ -141,7 +141,7 @@ if [[ "$REGISTER_NODE" == true ]]; then
     ZKCONFIG=$(zkConfig)
     set -e
     echo Registering node and writing local configuration to disk.
-    java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar add $ZKURL $MYID  $ZKCONFIG $DYNCONFIG
+    java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /opt/zookeeper-libs/zu.jar add $ZKURL $MYID  $ZKCONFIG $DYNCONFIG
     set +e
 fi
 

--- a/docker/bin/zookeeperTeardown.sh
+++ b/docker/bin/zookeeperTeardown.sh
@@ -38,11 +38,11 @@ set -e
 MYID=`cat $MYID_FILE`
 
 ZNODE_PATH="/zookeeper-operator/$CLUSTER_NAME"
-CLUSTERSIZE=`java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar sync $ZKURL $ZNODE_PATH`
+CLUSTERSIZE=`java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /opt/zookeeper-libs/zu.jar sync $ZKURL $ZNODE_PATH`
 echo "CLUSTER_SIZE=$CLUSTERSIZE, MyId=$MYID"
 if [[ -n "$CLUSTERSIZE" && "$CLUSTERSIZE" -lt "$MYID" ]]; then
   # If ClusterSize < MyId, this server is being permanantly removed.
-  java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /root/zu.jar remove $ZKURL $MYID
+  java -Dlog4j.configuration=file:"$LOG4J_CONF" -jar /opt/zookeeper-libs/zu.jar remove $ZKURL $MYID
   echo $?
 fi
 


### PR DESCRIPTION
### Change log description

* Changed location of `zu.jar` file in zookeeper image
* Fixed path to `zu.jar` file in shell scripts

### Purpose of the change

Correct launch of the zookeeper in OpenShift. Using the `/root/` folder in containers is bad practice.

### How to verify it

Tested in OpenShift version 4.5:
* install operator
* create ZookeeperCluster object
