### PR TITLE
Issue 300: Zookeeper Operator pre-delete hook

### DIFF
--- a/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
+++ b/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
@@ -1,0 +1,110 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+rules:
+- apiGroups:
+  - zookeeper.pravega.io
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+data:
+  pre-delete.sh: |
+    #!/bin/sh
+    exit_code=0
+    echo "Checking for ZookeeperCluster Resource"
+
+    ret=$(kubectl get zookeepercluster --all-namespaces --no-headers 2>&1)
+    if (echo $ret | grep -e "No resources found" -e "the server doesn't have a resource type \"zookeepercluster\"" > /dev/null);
+    then
+      echo "None"
+    else
+      echo "$ret"
+      exit_code=1
+    fi
+
+    if [ $exit_code -ne 0 ];
+    then
+      echo "Pre-delete Check Failed"
+      exit $exit_code
+    fi
+    echo "Pre-delete Check OK"
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 20
+  template:
+    metadata:
+      name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
+    spec:
+      serviceAccountName: {{ template "zookeeper-operator.fullname" . }}-pre-delete
+      restartPolicy: Never
+      containers:
+        - name: pre-delete-job
+          image: "{{ .Values.hooks.image.repository }}:{{ .Values.hooks.image.tag }}"
+          command:
+            - /scripts/pre-delete.sh
+          volumeMounts:
+            - name: sh
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: sh
+          configMap:
+            name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
+            defaultMode: 0555

--- a/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
+++ b/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.hooks.delete }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -108,3 +109,4 @@ spec:
           configMap:
             name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
             defaultMode: 0555
+{{- end }}

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -54,3 +54,7 @@ hooks:
   image:
     repository: lachlanevenson/k8s-kubectl
     tag: v1.16.10
+  ## Whether to create pre-delete hook which ensures that
+  ## the operator cannot be deleted till the zookeeper cluster
+  ## custom resources have been cleaned up
+  delete: true


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Provides a pre-delete hook which ensures that custom resources are deleted before deleting the operator.

### Purpose of the change
Fixes #300 

### What the code does
Allows the operator to be deleted via helm only if the zookeepercluster custom resource has already been deleted, not otherwise.

### How to verify it
- If you try to delete the zookeeper operator before having deleted the zookeeper cluster resource, the pre-delete job will fail, thereby not allowing the operator from being deleted.
- If you try to delete the zookeeper operator after the zookeeper cluster resource has been cleaned up successfully, the operator will also be successfully deleted.
