### PR TITLE
Issue 299: Fix incorrect paths in config spec

### DIFF
--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -111,22 +111,22 @@ spec:
     commitLogCount: {{ .Values.config.commitLogCount }}
     {{- end }}
     {{- if .Values.config.snapSizeLimitInKb }}
-    snapSizeLimitInKb: {{ .Values.snapSizeLimitInKb }}
+    snapSizeLimitInKb: {{ .Values.config.snapSizeLimitInKb }}
     {{- end }}
     {{- if .Values.config.maxCnxns }}
-    maxCnxns: {{ .Values.maxCnxns }}
+    maxCnxns: {{ .Values.config.maxCnxns }}
     {{- end }}
     {{- if .Values.config.maxClientCnxns }}
-    maxClientCnxns: {{ .Values.maxClientCnxns }}
+    maxClientCnxns: {{ .Values.config.maxClientCnxns }}
     {{- end }}
     {{- if .Values.config.minSessionTimeout }}
-    minSessionTimeout: {{ .Values.minSessionTimeout }}
+    minSessionTimeout: {{ .Values.config.minSessionTimeout }}
     {{- end }}
     {{- if .Values.config.maxSessionTimeout }}
-    maxSessionTimeout: {{ .Values.maxSessionTimeout }}
+    maxSessionTimeout: {{ .Values.config.maxSessionTimeout }}
     {{- end }}
     {{- if .Values.config.autoPurgeSnapRetainCount }}
-    autoPurgeSnapRetainCount: {{ .Values.autoPurgeSnapRetainCount }}
+    autoPurgeSnapRetainCount: {{ .Values.config.autoPurgeSnapRetainCount }}
     {{- end }}
     {{- if .Values.config.autoPurgePurgeInterval }}
     autoPurgePurgeInterval: {{ .Values.config.autoPurgePurgeInterval }}


### PR DESCRIPTION
### Change log description

Fix Helm config spec cannot be set because the some paths are incorrect

### Purpose of the change

Fixes #299 

### What the code does

Typos fixed

### How to verify it

Changes in snapSizeLimitInKb, maxCnxns, maxClientCnxns, minSessionTimeout, maxSessionTimeout, autoPurgeSnapRetainCount should be applied to configMap and to zoo.cfg
