### PR TITLE
Alternate zk versions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,9 @@ COPY zu /zu
 WORKDIR /zu
 RUN ./gradlew --console=verbose --info shadowJar
 
-FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}zookeeper:3.6.1
+# Also update ZOOKEEPER_VERSION in the Makefile
+ARG ZOOKEEPER_VERSION=3.6.1
+FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}zookeeper:${ZOOKEEPER_VERSION}
 COPY bin /usr/local/bin
 RUN chmod +x /usr/local/bin/*
 COPY --from=0 /zu/build/libs/zu.jar /root/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,15 +8,16 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 
+# Also update ZOOKEEPER_VERSION in the Makefile
+ARG ZOOKEEPER_VERSION=3.6.1
+
 ARG DOCKER_REGISTRY
 FROM  ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}openjdk:11-jdk
 RUN mkdir /zu
 COPY zu /zu
 WORKDIR /zu
-RUN ./gradlew --console=verbose --info shadowJar
+RUN ./gradlew --console=verbose --info shadowJar -PzookeeperVersion=${ZOOKEEPER_VERSION}
 
-# Also update ZOOKEEPER_VERSION in the Makefile
-ARG ZOOKEEPER_VERSION=3.6.1
 FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}zookeeper:${ZOOKEEPER_VERSION}
 COPY bin /usr/local/bin
 RUN chmod +x /usr/local/bin/*

--- a/docker/zu/build.gradle.kts
+++ b/docker/zu/build.gradle.kts
@@ -10,9 +10,11 @@ repositories {
     mavenCentral()
 }
 
+val zookeeperVersion: String by project
+
 dependencies {
     implementation(kotlin("stdlib"))
-    implementation("org.apache.zookeeper:zookeeper:3.6.1")
+    implementation("org.apache.zookeeper:zookeeper:$zookeeperVersion")
 }
 
 tasks.withType<ShadowJar>() {


### PR DESCRIPTION
### Change log description

Added a simple way to use a different version of ZooKeeper.

### Purpose of the change

Fixes #286

### What the code does

By running `make zk-build-image ZOOKEEPER_VERSION=3.5.5` you could, for example, build a zookeeper image with version 3.5.5 instead of the default 3.6.1. 

Note, however, that 3.5.5 is the oldest version that this Operator can support. It depends on the dynamic reconfig feature which was added in 3.5.3. As 3.5.5 is the first stable release of the 3.5.y series, so it is the first release to include this feature.

### How to verify it

Build it. Use it.
You'll need to pass in the name/version of your custom docker image when configuring the operator, eg via values in the Helm chart.
