### PR TITLE
Issue 307: Provide a way for customization of annotations for service…

### DIFF
--- a/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -2426,9 +2426,9 @@ spec:
               description: AdminServerService defines the policy to create AdminServer Service
                 for the zookeeper cluster.
               properties:
-                internal:
-                  description: Internal specifies if LoadBalancer should be created for
-                    the AdminServer. False means LoadBalancer will be created, true means ClusterIP
+                external:
+                  description: External specifies if LoadBalancer should be created for
+                    the AdminServer. True means LoadBalancer will be created, false means ClusterIP
                     will be used. Default is false.
                   type: boolean
                 annotations:

--- a/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -2400,6 +2400,44 @@ spec:
                     type: object
                   type: array
               type: object
+            clientService:
+              description: ClientService defines the policy to create client Service
+                for the zookeeper cluster.
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description: Annotations specifies the annotations to attach to
+                    client Service the operator creates.
+                  type: object
+              type: object
+            headlessService:
+              description: HeadlessService defines the policy to create headless Service
+                for the zookeeper cluster.
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description: Annotations specifies the annotations to attach to
+                    headless Service the operator creates.
+                  type: object
+              type: object
+            adminServerService:
+              description: AdminServerService defines the policy to create AdminServer Service
+                for the zookeeper cluster.
+              properties:
+                internal:
+                  description: Internal specifies if LoadBalancer should be created for
+                    the AdminServer. False means LoadBalancer will be created, true means ClusterIP
+                    will be used. Default is false.
+                  type: boolean
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description: Annotations specifies the annotations to attach to AdminServer
+                    Service the operator creates.
+                  type: object
+              type: object
             ports:
               items:
                 description: ContainerPort represents a network port in a single container.

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -82,6 +82,13 @@ The following table lists the configurable parameters of the zookeeper chart and
 | `pod.terminationGracePeriodSeconds` | Amount of time given to the pod to shutdown normally | `30` |
 | `pod.serviceAccountName` | Name for the service account | `zookeeper` |
 | `pod.imagePullSecrets` | ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images. | `[]` |
+| `clientService` | Defines the policy to create client Service for the zookeeper cluster. | {} |
+| `clientService.annotations` | Specifies the annotations to attach to client Service the operator creates. | {} |
+| `headlessService` | Defines the policy to create headless Service for the zookeeper cluster. | {} |
+| `headlessService.annotations` | Specifies the annotations to attach to headless Service the operator creates. | {} |
+| `adminServerService` | Defines the policy to create AdminServer Service for the zookeeper cluster. | {} |
+| `adminServerService.annotations` | Specifies the annotations to attach to AdminServer Service the operator creates. | {} |
+| `adminServerService.internal` | Specifies if LoadBalancer should be created for the AdminServer. False means LoadBalancer will be created, true - only ClusterIP will be used. | false |
 | `config.initLimit` | Amount of time (in ticks) to allow followers to connect and sync to a leader | `10` |
 | `config.tickTime` | Length of a single tick which is the basic time unit used by Zookeeper (measured in milliseconds) | `2000` |
 | `config.syncLimit` | Amount of time (in ticks) to allow followers to sync with Zookeeper | `2` |

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -88,7 +88,7 @@ The following table lists the configurable parameters of the zookeeper chart and
 | `headlessService.annotations` | Specifies the annotations to attach to headless Service the operator creates. | {} |
 | `adminServerService` | Defines the policy to create AdminServer Service for the zookeeper cluster. | {} |
 | `adminServerService.annotations` | Specifies the annotations to attach to AdminServer Service the operator creates. | {} |
-| `adminServerService.internal` | Specifies if LoadBalancer should be created for the AdminServer. False means LoadBalancer will be created, true - only ClusterIP will be used. | false |
+| `adminServerService.external` | Specifies if LoadBalancer should be created for the AdminServer. True means LoadBalancer will be created, false - only ClusterIP will be used. | false |
 | `config.initLimit` | Amount of time (in ticks) to allow followers to connect and sync to a leader | `10` |
 | `config.tickTime` | Length of a single tick which is the basic time unit used by Zookeeper (measured in milliseconds) | `2000` |
 | `config.syncLimit` | Amount of time (in ticks) to allow followers to sync with Zookeeper | `2` |

--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -87,6 +87,24 @@ spec:
     imagePullSecrets:
 {{ toYaml .Values.pod.imagePullSecrets | indent 6 }}
     {{- end }}
+  clientService:
+    {{- if .Values.clientService.annotations }}
+    annotations:
+{{ toYaml .Values.clientService.annotations | indent 6 }}
+    {{- end }}
+  headlessService:
+    {{- if .Values.headlessService.annotations }}
+    annotations:
+{{ toYaml .Values.headlessService.annotations | indent 6 }}
+    {{- end }}
+  adminServerService:
+    {{- if .Values.adminServerService.annotations }}
+    annotations:
+{{ toYaml .Values.adminServerService.annotations | indent 6 }}
+    {{- end }}
+    {{- if .Values.adminServerService.internal }}
+    internal: {{ .Values.adminServerService.internal }}
+    {{- end }}
   {{- if .Values.config }}
   config:
     {{- if .Values.config.initLimit }}

--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -107,8 +107,8 @@ spec:
     annotations:
 {{ toYaml .Values.adminServerService.annotations | indent 6 }}
     {{- end }}
-    {{- if .Values.adminServerService.internal }}
-    internal: {{ .Values.adminServerService.internal }}
+    {{- if .Values.adminServerService.external }}
+    external: {{ .Values.adminServerService.external }}
     {{- end }}
   {{- end }}
   {{- if .Values.config }}

--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -87,16 +87,21 @@ spec:
     imagePullSecrets:
 {{ toYaml .Values.pod.imagePullSecrets | indent 6 }}
     {{- end }}
+  {{- if .Values.clientService }}
   clientService:
     {{- if .Values.clientService.annotations }}
     annotations:
 {{ toYaml .Values.clientService.annotations | indent 6 }}
     {{- end }}
+  {{- end }}
+  {{- if .Values.headlessService }}
   headlessService:
     {{- if .Values.headlessService.annotations }}
     annotations:
 {{ toYaml .Values.headlessService.annotations | indent 6 }}
     {{- end }}
+  {{- end }}
+  {{- if .Values.adminServerService }}
   adminServerService:
     {{- if .Values.adminServerService.annotations }}
     annotations:
@@ -105,6 +110,7 @@ spec:
     {{- if .Values.adminServerService.internal }}
     internal: {{ .Values.adminServerService.internal }}
     {{- end }}
+  {{- end }}
   {{- if .Values.config }}
   config:
     {{- if .Values.config.initLimit }}

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -40,6 +40,16 @@ pod:
   serviceAccountName: zookeeper
   # imagePullSecrets: []
 
+adminServerService:
+  # annotations: {}
+  # internal: false
+
+clientService:
+  # annotations: {}
+
+headlessService:
+  # annotations: {}
+
 config: {}
   # initLimit: 10
   # tickTime: 2000

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -42,7 +42,7 @@ pod:
 
 adminServerService: {}
   # annotations: {}
-  # internal: false
+  # external: false
 
 clientService: {}
   # annotations: {}

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -40,14 +40,14 @@ pod:
   serviceAccountName: zookeeper
   # imagePullSecrets: []
 
-adminServerService:
+adminServerService: {}
   # annotations: {}
   # internal: false
 
-clientService:
+clientService: {}
   # annotations: {}
 
-headlessService:
+headlessService: {}
   # annotations: {}
 
 config: {}

--- a/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -2396,6 +2396,44 @@ spec:
                     type: object
                   type: array
               type: object
+            clientService:
+              description: ClientService defines the policy to create client Service
+                for the zookeeper cluster.
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description: Annotations specifies the annotations to attach to
+                    client Service the operator creates.
+                  type: object
+              type: object
+            headlessService:
+              description: HeadlessService defines the policy to create headless Service
+                for the zookeeper cluster.
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description: Annotations specifies the annotations to attach to
+                    headless Service the operator creates.
+                  type: object
+              type: object
+            adminServerService:
+              description: AdminServerService defines the policy to create AdminServer Service
+                for the zookeeper cluster.
+              properties:
+                internal:
+                  description: Internal specifies if LoadBalancer should be created for
+                    the AdminServer. False means LoadBalancer will be created, true means ClusterIP
+                    will be used. Default is false.
+                  type: boolean
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description: Annotations specifies the annotations to attach to AdminServer
+                    Service the operator creates.
+                  type: object
+              type: object
             ports:
               items:
                 description: ContainerPort represents a network port in a single container.

--- a/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/deploy/crds/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -2422,9 +2422,9 @@ spec:
               description: AdminServerService defines the policy to create AdminServer Service
                 for the zookeeper cluster.
               properties:
-                internal:
-                  description: Internal specifies if LoadBalancer should be created for
-                    the AdminServer. False means LoadBalancer will be created, true means ClusterIP
+                external:
+                  description: External specifies if LoadBalancer should be created for
+                    the AdminServer. True means LoadBalancer will be created, false means ClusterIP
                     will be used. Default is false.
                   type: boolean
                 annotations:

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -100,6 +100,12 @@ type ZookeeperClusterSpec struct {
 	// Updating the Pod does not take effect on any existing pods.
 	Pod PodPolicy `json:"pod,omitempty"`
 
+	AdminServerService AdminServerServicePolicy `json:"adminServerService,omitempty"`
+
+	ClientService ClientServicePolicy `json:"clientService,omitempty"`
+
+	HeadlessService HeadlessServicePolicy `json:"headlessService,omitempty"`
+
 	//StorageType is used to tell which type of storage we will be using
 	//It can take either Ephemeral or persistence
 	//Default StorageType is Persistence storage
@@ -486,6 +492,26 @@ func (p *PodPolicy) withDefaults(z *ZookeeperCluster) (changed bool) {
 		changed = true
 	}
 	return changed
+}
+
+type AdminServerServicePolicy struct {
+	// Annotations specifies the annotations to attach to AdminServer service the operator
+	// creates.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	Internal bool `json:"internal,omitempty"`
+}
+
+type ClientServicePolicy struct {
+	// Annotations specifies the annotations to attach to client service the operator
+	// creates.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+type HeadlessServicePolicy struct {
+	// Annotations specifies the annotations to attach to headless service the operator
+	// creates.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 func (s *Probes) withDefaults() (changed bool) {

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -499,7 +499,7 @@ type AdminServerServicePolicy struct {
 	// creates.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
-	Internal bool `json:"internal,omitempty"`
+	External bool `json:"external,omitempty"`
 }
 
 type ClientServicePolicy struct {

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -201,7 +201,7 @@ func MakeAdminServerService(z *v1beta1.ZookeeperCluster) *v1.Service {
 	svcPorts := []v1.ServicePort{
 		{Name: "tcp-admin-server", Port: ports.AdminServer},
 	}
-	external := !z.Spec.AdminServerService.Internal
+	external := z.Spec.AdminServerService.External
 	annotations := z.Spec.AdminServerService.Annotations
 	return makeService(z.GetAdminServerServiceName(), svcPorts, true, external, annotations, z)
 }

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -191,7 +191,7 @@ func MakeClientService(z *v1beta1.ZookeeperCluster) *v1.Service {
 	svcPorts := []v1.ServicePort{
 		{Name: "tcp-client", Port: ports.Client},
 	}
-	return makeService(z.GetClientServiceName(), svcPorts, true, false, z)
+	return makeService(z.GetClientServiceName(), svcPorts, true, false, z.Spec.ClientService.Annotations, z)
 }
 
 // MakeAdminServerService returns a service which provides an interface
@@ -201,7 +201,9 @@ func MakeAdminServerService(z *v1beta1.ZookeeperCluster) *v1.Service {
 	svcPorts := []v1.ServicePort{
 		{Name: "tcp-admin-server", Port: ports.AdminServer},
 	}
-	return makeService(z.GetAdminServerServiceName(), svcPorts, true, true, z)
+	external := !z.Spec.AdminServerService.Internal
+	annotations := z.Spec.AdminServerService.Annotations
+	return makeService(z.GetAdminServerServiceName(), svcPorts, true, external, annotations, z)
 }
 
 // MakeConfigMap returns a zookeeper config map
@@ -236,7 +238,7 @@ func MakeHeadlessService(z *v1beta1.ZookeeperCluster) *v1.Service {
 		{Name: "tcp-metrics", Port: ports.Metrics},
 		{Name: "tcp-admin-server", Port: ports.AdminServer},
 	}
-	return makeService(headlessSvcName(z), svcPorts, false, false, z)
+	return makeService(headlessSvcName(z), svcPorts, false, false, z.Spec.HeadlessService.Annotations, z)
 }
 
 func makeZkConfigString(z *v1beta1.ZookeeperCluster) string {
@@ -300,9 +302,9 @@ func makeZkEnvConfigString(z *v1beta1.ZookeeperCluster) string {
 		"CLUSTER_SIZE=" + fmt.Sprint(z.Spec.Replicas) + "\n"
 }
 
-func makeService(name string, ports []v1.ServicePort, clusterIP bool, external bool, z *v1beta1.ZookeeperCluster) *v1.Service {
+func makeService(name string, ports []v1.ServicePort, clusterIP bool, external bool, annotations map[string]string, z *v1beta1.ZookeeperCluster) *v1.Service {
 	var dnsName string
-	var annotationMap map[string]string
+	var annotationMap = copyMap(annotations)
 	if !clusterIP && z.Spec.DomainName != "" {
 		domainName := strings.TrimSpace(z.Spec.DomainName)
 		if strings.HasSuffix(domainName, dot) {
@@ -310,9 +312,7 @@ func makeService(name string, ports []v1.ServicePort, clusterIP bool, external b
 		} else {
 			dnsName = name + dot + domainName + dot
 		}
-		annotationMap = map[string]string{externalDNSAnnotationKey: dnsName}
-	} else {
-		annotationMap = map[string]string{}
+		annotationMap[externalDNSAnnotationKey] = dnsName
 	}
 	service := v1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -334,7 +334,7 @@ func makeService(name string, ports []v1.ServicePort, clusterIP bool, external b
 		},
 	}
 	if external {
-		service.Spec.Type = "LoadBalancer"
+		service.Spec.Type = v1.ServiceTypeLoadBalancer
 	}
 	if !clusterIP {
 		service.Spec.ClusterIP = v1.ClusterIPNone
@@ -385,6 +385,16 @@ func mergeLabels(l ...map[string]string) map[string]string {
 		for lKey, lValue := range v {
 			res[lKey] = lValue
 		}
+	}
+	return res
+}
+
+// Make a copy of map
+func copyMap(s map[string]string) map[string]string {
+	res := make(map[string]string)
+
+	for lKey, lValue := range s {
+		res[lKey] = lValue
 	}
 	return res
 }

--- a/pkg/zk/generators_test.go
+++ b/pkg/zk/generators_test.go
@@ -493,12 +493,12 @@ var _ = Describe("Generators Spec", func() {
 				"exampleValue"))
 		})
 
-		It("should have LoadBalancer attached by default", func() {
-			Ω(s.Spec.Type).To(Equal(v1.ServiceTypeLoadBalancer))
+		It("should have no LoadBalancer attached by default", func() {
+			Ω(s.Spec.Type).NotTo(Equal(v1.ServiceTypeLoadBalancer))
 		})
 	})
 
-	Context("#MakeAdminServerService internal without LoadBalancer", func() {
+	Context("#MakeAdminServerService external with LoadBalancer", func() {
 		var s *v1.Service
 
 		BeforeEach(func() {
@@ -509,7 +509,7 @@ var _ = Describe("Generators Spec", func() {
 				},
 				Spec: v1beta1.ZookeeperClusterSpec{
 					AdminServerService: v1beta1.AdminServerServicePolicy{
-						Internal: true,
+						External: true,
 					},
 				},
 			}
@@ -517,8 +517,8 @@ var _ = Describe("Generators Spec", func() {
 			s = zk.MakeAdminServerService(z)
 		})
 
-		It("should have no LoadBalancer attached", func() {
-			Ω(s.Spec.Type).NotTo(Equal(v1.ServiceTypeLoadBalancer))
+		It("should have LoadBalancer attached", func() {
+			Ω(s.Spec.Type).To(Equal(v1.ServiceTypeLoadBalancer))
 		})
 	})
 

--- a/pkg/zk/generators_test.go
+++ b/pkg/zk/generators_test.go
@@ -297,6 +297,11 @@ var _ = Describe("Generators Spec", func() {
 					Labels: map[string]string{
 						"exampleLabel": "exampleValue",
 					},
+					ClientService: v1beta1.ClientServicePolicy{
+						Annotations: map[string]string{
+							"exampleAnnotation": "exampleValue",
+						},
+					},
 				},
 			}
 			z.WithDefaults()
@@ -318,13 +323,18 @@ var _ = Describe("Generators Spec", func() {
 		})
 
 		It("should not set the dns annotation", func() {
-			mapLength := len(s.GetAnnotations())
-			Ω(mapLength).To(Equal(0))
+			Expect(s.GetAnnotations()).NotTo(HaveKey("external-dns.alpha.kubernetes.io/hostname"))
 		})
 
 		It("should have custom labels set", func() {
 			Ω(s.GetLabels()).To(HaveKeyWithValue(
 				"exampleLabel",
+				"exampleValue"))
+		})
+
+		It("should have custom annotations set", func() {
+			Ω(s.GetAnnotations()).To(HaveKeyWithValue(
+				"exampleAnnotation",
 				"exampleValue"))
 		})
 	})
@@ -344,6 +354,11 @@ var _ = Describe("Generators Spec", func() {
 					DomainName: domainName,
 					Labels: map[string]string{
 						"exampleLabel": "exampleValue",
+					},
+					HeadlessService: v1beta1.HeadlessServicePolicy{
+						Annotations: map[string]string{
+							"exampleAnnotation": "exampleValue",
+						},
 					},
 				},
 			}
@@ -394,6 +409,12 @@ var _ = Describe("Generators Spec", func() {
 				"exampleLabel",
 				"exampleValue"))
 		})
+
+		It("should have custom annotations set", func() {
+			Ω(s.GetAnnotations()).To(HaveKeyWithValue(
+				"exampleAnnotation",
+				"exampleValue"))
+		})
 	})
 
 	Context("#MakeHeadlessService dnsname without dot", func() {
@@ -435,6 +456,11 @@ var _ = Describe("Generators Spec", func() {
 					Labels: map[string]string{
 						"exampleLabel": "exampleValue",
 					},
+					AdminServerService: v1beta1.AdminServerServicePolicy{
+						Annotations: map[string]string{
+							"exampleAnnotation": "exampleValue",
+						},
+					},
 				},
 			}
 			z.WithDefaults()
@@ -459,6 +485,40 @@ var _ = Describe("Generators Spec", func() {
 			Ω(s.GetLabels()).To(HaveKeyWithValue(
 				"exampleLabel",
 				"exampleValue"))
+		})
+
+		It("should have custom annotations set", func() {
+			Ω(s.GetAnnotations()).To(HaveKeyWithValue(
+				"exampleAnnotation",
+				"exampleValue"))
+		})
+
+		It("should have LoadBalancer attached by default", func() {
+			Ω(s.Spec.Type).To(Equal(v1.ServiceTypeLoadBalancer))
+		})
+	})
+
+	Context("#MakeAdminServerService internal without LoadBalancer", func() {
+		var s *v1.Service
+
+		BeforeEach(func() {
+			z := &v1beta1.ZookeeperCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example",
+					Namespace: "default",
+				},
+				Spec: v1beta1.ZookeeperClusterSpec{
+					AdminServerService: v1beta1.AdminServerServicePolicy{
+						Internal: true,
+					},
+				},
+			}
+			z.WithDefaults()
+			s = zk.MakeAdminServerService(z)
+		})
+
+		It("should have no LoadBalancer attached", func() {
+			Ω(s.Spec.Type).NotTo(Equal(v1.ServiceTypeLoadBalancer))
 		})
 	})
 


### PR DESCRIPTION
### Change log description

A way for customization of annotations for services and for making LoadBalancer optional for AdminServer service has been added.

### Purpose of the change

Fixes #307 

### What the code does

- clientService, headlessService, adminServerService were added to CRD
- support of new objects added to generators.go
- new code covered with tests

### How to verify it

Adding annotations to clientService/headlessService/adminServerService should lead to attaching corresponding annotations to k8s Service's.
Adding `adminServerService.internal: true` should lead to creating k8s Service with ClusterIP without LoadBalancer.