### PR TITLE
Issue 312: list PVC with ZookeeperCluster uid

### DIFF
--- a/pkg/controller/zookeepercluster/zookeepercluster_controller.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller.go
@@ -722,7 +722,7 @@ func (r *ReconcileZookeeperCluster) cleanupOrphanPVCs(instance *zookeeperv1beta1
 
 func (r *ReconcileZookeeperCluster) getPVCList(instance *zookeeperv1beta1.ZookeeperCluster) (pvList corev1.PersistentVolumeClaimList, err error) {
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
-		MatchLabels: map[string]string{"app": instance.GetName()},
+		MatchLabels: map[string]string{"app": instance.GetName(), "uid": string(instance.UID)},
 	})
 	pvclistOps := &client.ListOptions{
 		Namespace:     instance.Namespace,

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -57,7 +57,7 @@ func MakeStatefulSet(z *v1beta1.ZookeeperCluster) *appsv1.StatefulSet {
 				Name: zkDataVolume,
 				Labels: mergeLabels(
 					z.Spec.Labels,
-					map[string]string{"app": z.GetName()},
+					map[string]string{"app": z.GetName(), "uid": string(z.UID)},
 				),
 				Annotations: z.Spec.Persistence.Annotations,
 			},


### PR DESCRIPTION
### Change log description

Add UID as a label for each PVC in `MakeStatefulSet` and list PVC using the UID in `getPVCList`.

### Purpose of the change

Fix https://github.com/pravega/zookeeper-operator/issues/312.

### What the code does

- `MakeStatefulSet`: One more label, uid, when creating VolumeClaimTemplates
- `getPVCList`: List the PVC with the uid of the current ZookeeperCluster

### How to verify it

- Normal PVC creation/deletion without node failures can still work
- As described in https://github.com/pravega/zookeeper-operator/issues/312, the reproduction steps will not trigger PVC deletion
