### PR TITLE
Remove the skipACL property from zoo.cfg; users can add via the SERVER_JVMFLAGS env var if needed

### DIFF
--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -226,7 +226,6 @@ func makeZkConfigString(s v1beta1.ZookeeperClusterSpec) string {
 		"dataDir=/data\n" +
 		"standaloneEnabled=false\n" +
 		"reconfigEnabled=true\n" +
-		"skipACL=yes\n" +
 		"metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider\n" +
 		"metricsProvider.httpPort=7000\n" +
 		"metricsProvider.exportJvmInfo=true\n" +

--- a/pkg/zk/generators_test.go
+++ b/pkg/zk/generators_test.go
@@ -79,10 +79,6 @@ var _ = Describe("Generators Spec", func() {
 					Ω(cfg).To(ContainSubstring("reconfigEnabled=true\n"))
 				})
 
-				It("should set skipACL to 'yes'", func() {
-					Ω(cfg).To(ContainSubstring("skipACL=yes"))
-				})
-
 				It("should set initLimit to '10'", func() {
 					Ω(cfg).To(ContainSubstring("initLimit=10\n"))
 				})


### PR DESCRIPTION
### Change log description

Don't force `skipACL` to `yes` in zoo.cfg; if users need this, they can set via the SERVER_JVMFLAGS env var if needed, e.g. `SERVER_JVMFLAGS=-Dzookeeper.skipACL=yes`

The operator should not be disabling security features without good reason.

### Purpose of the change

Fixes #316 

### What the code does

Removes the `skipACL=yes` from the generated zoo.cfg, which disables ACL enforcement and is a security risk.

Removing this property breaks multi-node ensembles, but seems like the operator should just read creds from a K8s secret vs. disabling the entire ACL / security system?

### How to verify it

TODO ...
