### PR TITLE
Issue 329: CRD apiVersion check

### DIFF
--- a/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
+++ b/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.hooks.delete }}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
   annotations:
@@ -18,7 +18,7 @@ rules:
 ---
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
   annotations:

--- a/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.crd.create }}
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1" }}
+apiVersion: apiextensions.k8s.io/v1
+{{- else }}
 apiVersion: apiextensions.k8s.io/v1beta1
+{{- end }}
 kind: CustomResourceDefinition
 metadata:
   name: zookeeperclusters.zookeeper.pravega.io


### PR DESCRIPTION
### Change log description

- Add the capability to install the chart in eks versions that don't support apiVersion=apiextensions.k8s.io/v1beta1 anymore

### Purpose of the change
Closes #329 

### What the code does

The code is using .Capabilities.APIVersions.Has to check for the apiVersion apiextensions.k8s.io/v1, if it finds it it uses to create the CRD, if it doesn't it falls back to apiextensions.k8s.io/v1beta1

### How to verify it

You are able to install the chart with the CRD in eks v1.19.0 version from which apiextensions.k8s.io/v1beta1 was removed
