### PR TITLE
Issue 333: Fix Pod SecurityContext config error in ZK charts

### DIFF
--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -175,7 +175,7 @@ func makeZkPodSpec(z *v1beta1.ZookeeperCluster, volumes []v1.Volume) v1.PodSpec 
 		Affinity:   z.Spec.Pod.Affinity,
 		Volumes:    append(z.Spec.Volumes, volumes...),
 	}
-	if reflect.DeepEqual(v1.PodSecurityContext{}, z.Spec.Pod.SecurityContext) {
+	if !reflect.DeepEqual(v1.PodSecurityContext{}, z.Spec.Pod.SecurityContext) {
 		podSpec.SecurityContext = z.Spec.Pod.SecurityContext
 	}
 	podSpec.NodeSelector = z.Spec.Pod.NodeSelector


### PR DESCRIPTION
### Change log description

1. Fix Pod SecurityContext config error in ZK charts

### Purpose of the change
Close #333 

### What the code does

1. Fix Pod SecurityContext config error in ZK charts

### How to verify it

Create a ZK CR with  Pod.SecurityContext  config, then check the created ZK StatufulSet config if contained 
correct Pod.SecurityContext
