### PR TITLE
Adding sidecar features to zookeeper-operator

### DIFF
--- a/charts/zookeeper-operator/README.md
+++ b/charts/zookeeper-operator/README.md
@@ -53,3 +53,6 @@ The following table lists the configurable parameters of the zookeeper-operator 
 | `nodeSelector` | Map of key-value pairs to be present as labels in the node in which the pod should run | `{}` |
 | `affinity` | Specifies scheduling constraints on pods | `{}` |
 | `tolerations` | Specifies the pod's tolerations | `[]` |
+| `additionalEnv` | Additional Environment Variables | `[]` |
+| `additionalSidecars` | Additional Sidecars Configuration | `[]` |
+| `additionalVolumes` | Additional volumes required for sidecars | `[]` |

--- a/charts/zookeeper-operator/templates/_helpers.tpl
+++ b/charts/zookeeper-operator/templates/_helpers.tpl
@@ -35,3 +35,17 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- end -}}
+
+{{/*
+Sidecar implementation details
+*/}}
+{{- define "chart.additionalSidecars"}}
+{{ toYaml .Values.additionalSidecars }}
+{{- end}}
+
+{{/*
+Sidecar volume implementation details
+*/}}
+{{- define "chart.additionalVolumes"}}
+{{ toYaml .Values.additionalVolumes }}
+{{- end}}

--- a/charts/zookeeper-operator/templates/operator.yaml
+++ b/charts/zookeeper-operator/templates/operator.yaml
@@ -21,6 +21,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- if .Values.additionalVolumes }}
+      volumes:
+{{- include "chart.additionalVolumes" . | indent 6 }}
+      {{- end }}
       containers:
       - name: {{ template "zookeeper-operator.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -39,10 +43,16 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: {{ template "zookeeper-operator.fullname" . }}
+        {{- if .Values.additionalEnv }}
+{{ toYaml .Values.additionalEnv | indent 8 }}
+        {{- end }}
         {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         {{- end }}
+      {{- if .Values.additionalSidecars }}
+{{- include "chart.additionalSidecars" . | indent 6 }}
+      {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -58,3 +58,18 @@ hooks:
   ## the operator cannot be deleted till the zookeeper cluster
   ## custom resources have been cleaned up
   delete: true
+
+## Additional Sidecars Configuration.
+additionalSidecars: {}
+# - name: nginx
+#   image: nginx:latest
+
+## Additional Environment Variables.
+additionalEnv: {}
+
+## Additional volumes required for sidecars.
+additionalVolumes: {}
+# - name: volume1
+#   emptyDir: {}
+# - name: volume2
+#   emptyDir: {}


### PR DESCRIPTION
### Change log description
Adding sidecar features to zookeeper-operator

### Purpose of the change

Integrate. and enable the Sidecars with zookeeper-operator

### What the code does

Enable and. configure volumes and environment variables required for sidecars.


### How to verify it

1.Helm lint.
2.Update the .Values with Any Sidecar containers.
3.By adding required additional volumes and Environment variables.
4.helm template.
