### PR TITLE
issue #348 : added option to trigger cluster restart on static config change

### DIFF
--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -54,6 +54,7 @@ The following table lists the configurable parameters of the zookeeper chart and
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
 | `replicas` | Expected size of the zookeeper cluster (valid range is from 1 to 7) | `3` |
+| `restartOnConfigChange` | Determines whether the zookeeper cluster needs to be automatically restarted when static configs present in zoo.cfg are changes | false |
 | `image.repository` | Image repository | `pravega/zookeeper` |
 | `image.tag` | Image tag | `0.2.11` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |

--- a/charts/zookeeper/templates/zookeeper.yaml
+++ b/charts/zookeeper/templates/zookeeper.yaml
@@ -82,9 +82,14 @@ spec:
     env:
 {{ toYaml .Values.pod.env | indent 6 }}
     {{- end }}
-    {{- if .Values.pod.annotations }}
+    {{- if or (.Values.pod.annotations) (eq .Values.restartOnConfigChange true) }}
     annotations:
+      {{- if eq .Values.restartOnConfigChange true }}
+      checksum/config: {{ .Values.config | toString | sha256sum }}
+      {{- end }}
+      {{- if .Values.pod.annotations }}
 {{ toYaml .Values.pod.annotations | indent 6 }}
+      {{- end }}
     {{- end }}
     {{- if .Values.pod.securityContext }}
     securityContext:

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -1,4 +1,5 @@
 replicas: 3
+restartOnConfigChange: false
 
 image:
   repository: pravega/zookeeper

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -1,5 +1,4 @@
 replicas: 3
-
 restartOnConfigChange: false
 
 image:

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -1,4 +1,5 @@
 replicas: 3
+
 restartOnConfigChange: false
 
 image:


### PR DESCRIPTION
### Change log description

when static configs are changed (such as initTime, etc which go in zoo.cfg), the zookeeper cluster needs to be restarted in order for the configs to take effect. this change is to add a flag in the helm chart values to optionally trigger a cluster redeploy when static configs are modified.


### Purpose of the change

Refer https://github.com/pravega/zookeeper-operator/issues/348

### What the code does

these changes will compute a sha256 hash of the values which go into zoo.cfg via the config map. the hash is set as the value for a custom annotation in the pod spec for the zookeeper nodes. whenever the helm chart is uprgaded, the hash will be recomputed and the annotation will be updated. this update to the annotation will trigger a pod restart for all the nodes in the zookeeper cluster.

### How to verify it

1. create a zookeeper cluster using the helm chart
2. update the static configs in values.yaml for zookeeper chart
3. run "helm upgrade <chart-install-name> charts/zookeeper" from the root location of the project
4. check that the zookeeper pods are getting restarted by k8s using "kubectl get pods"