### PR TITLE
Issue 350: ZookeeperCluster crd's status disappear

### DIFF
--- a/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -32,6 +32,8 @@ spec:
     served: true
     storage: true
 {{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1" }}
+    subresources:
+      status: {}
 {{- include "crd.additionalPrinterColumns" . | indent 4}}
     schema:
 {{- include "crd.openAPIV3Schema" . | indent 6}}


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

Added sub resource field in CRD version `v1`

### Purpose of the change

Fixes #350

### What the code does

Modified CRD to update subresources

### How to verify it

Verify that `kubectl get zk` is showing the fields correctly. Also verify the output of `kuectl describe zk zookeeper`
