### PR TITLE
Added option to define templates for additional sidecars and volumes

### DIFF
--- a/charts/zookeeper-operator/templates/_helpers.tpl
+++ b/charts/zookeeper-operator/templates/_helpers.tpl
@@ -36,6 +36,20 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- end -}}
 
+{{/*
+Default sidecar template
+*/}}
+{{- define "chart.additionalSidecars"}}
+{{ toYaml .Values.additionalSidecars }}
+{{- end}}
+
+{{/*
+Default volume template
+*/}}
+{{- define "chart.additionalVolumes"}}
+{{ toYaml .Values.additionalVolumes }}
+{{- end}}
+
 {{- define "crd.additionalPrinterColumns" }}
 additionalPrinterColumns:
     - jsonPath: .spec.replicas

--- a/charts/zookeeper-operator/templates/operator.yaml
+++ b/charts/zookeeper-operator/templates/operator.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- if .Values.additionalVolumes }}
       volumes:
-{{ toYaml .Values.additionalVolumes | indent 6 }}
+{{- include "chart.additionalVolumes" . | indent 6 }}
       {{- end }}
       containers:
       - name: {{ template "zookeeper-operator.fullname" . }}
@@ -51,7 +51,7 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         {{- end }}
       {{- if .Values.additionalSidecars }}
-{{ toYaml .Values.additionalSidecars | indent 6 }}
+{{- include "chart.additionalSidecars" . | indent 6 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
### Change log description

Wrapped additionalSidecars and additionalVolumes inside named templates.

### Purpose of the change

Allows for defining templates for additionalSidecars/Volumes by extending the zookeeper-operator helm chart and overwriting `chart.*`.
Fixes  https://github.com/pravega/zookeeper-operator/issues/358
