### PR TITLE
fix issue-314 by checking zookeeperCluster resource version before updating sts ADDENDUM

### DIFF
--- a/pkg/controller/zookeepercluster/zookeepercluster_controller.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller.go
@@ -234,8 +234,8 @@ func (r *ReconcileZookeeperCluster) reconcileStatefulSet(instance *zookeeperv1be
 		return err
 	} else {
 		// check whether zookeeperCluster is updated before updating the sts
-		if !zookeeperClusterFresherThanSts(instance, sts) {
-			return fmt.Errorf("Staleness: cr.ResourceVersion %s is smaller than labeledRV %s", instance.ResourceVersion, sts.Labels["owner-rv"])
+		if !zookeeperClusterFresherThanSts(instance, foundSts) {
+			return fmt.Errorf("Staleness: cr.ResourceVersion %s is smaller than labeledRV %s", instance.ResourceVersion, foundSts.Labels["owner-rv"])
 		}
 		foundSTSSize := *foundSts.Spec.Replicas
 		newSTSSize := *sts.Spec.Replicas


### PR DESCRIPTION
Fix owner-rv check by checking the existing STS object


### Change log description

Previously the owner-rv label was looked up in the wrong object

### Purpose of the change

Fixes #314 
