### PR TITLE
Issue 357: Fix for error messages coming in operator logs

### DIFF
--- a/pkg/controller/zookeepercluster/zookeepercluster_controller.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller.go
@@ -341,7 +341,7 @@ func (r *ReconcileZookeeperCluster) clearUpgradeStatus(z *zookeeperv1beta1.Zooke
 	// when updating the CR below
 	status := z.Status.DeepCopy()
 
-	err = r.client.Status().Update(context.TODO(), z)
+	err = r.client.Update(context.TODO(), z)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

In ClearUpgradeStatus() function, we were not updating the zookeeper cluster, only the status was getting updated 2 times. Due to that again we try to update the cluster, was getting error as below.

, ```Operation cannot be fulfilled on zookeeperclusters.zookeeper.pravega.io \"zookeeper\": the object has been modified; please apply your changes to the latest version and try again"```  
### Purpose of the change

_Fixes #357

### What the code does

Update the cluster instance correctly

### How to verify it

Verify that during upgrade of zookeeper cluster, error messages are not coming frequently in operator logs.
