### PR TITLE
Issue 363: Fixing CRD to work with k8 1.15 version

### DIFF
--- a/charts/zookeeper-operator/templates/_crd_openapiv3schema.tpl
+++ b/charts/zookeeper-operator/templates/_crd_openapiv3schema.tpl
@@ -681,14 +681,13 @@ openAPIV3Schema:
                             type: string
                         required:
                         - containerPort
-                        {{- if semverCompare "< 1.18-0" .Capabilities.KubeVersion.GitVersion }}
-                        - protocol
-                        {{- end }}
                         type: object
                       type: array
                       x-kubernetes-list-map-keys:
                       - containerPort
+                      {{- if semverCompare "< 1.18-0" .Capabilities.KubeVersion.GitVersion }}
                       - protocol
+                      {{- end }}
                       x-kubernetes-list-type: map
                     readinessProbe:
                       description: 'Periodic probe of container service readiness.
@@ -1832,14 +1831,13 @@ openAPIV3Schema:
                             type: string
                         required:
                         - containerPort
-                        {{- if semverCompare "< 1.18-0" .Capabilities.KubeVersion.GitVersion }}
-                        - protocol
-                        {{- end }}
                         type: object
                       type: array
                       x-kubernetes-list-map-keys:
                       - containerPort
+                      {{- if semverCompare "< 1.18-0" .Capabilities.KubeVersion.GitVersion }}
                       - protocol
+                      {{- end }}
                       x-kubernetes-list-type: map
                     readinessProbe:
                       description: 'Periodic probe of container service readiness.
@@ -3551,9 +3549,6 @@ openAPIV3Schema:
                       type: string
                   required:
                   - containerPort
-                  {{- if semverCompare "< 1.18-0" .Capabilities.KubeVersion.GitVersion }}
-                  - protocol
-                  {{- end }}
                   type: object
                 type: array
               probes:


### PR DESCRIPTION
Fix issue in CRD


### Change log description

Change log description
helm install fails to install the new CRD in k8s 1.15
Fixing by reverting to using helm conditional on these old versions
### Purpose of the change

 Fixes #363

### What the code does

Fixed the CRD 

### How to verify it

Verified operator and cluster install works fine