### PR TITLE
Issue 371: Updating charts  to latest version

### DIFF
--- a/charts/zookeeper-operator/Chart.yaml
+++ b/charts/zookeeper-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: zookeeper-operator
 description: Zookeeper Operator Helm chart for Kubernetes
-version: 0.2.11
-appVersion: 0.2.11
+version: 0.2.12
+appVersion: 0.2.12
 keywords:
 - zookeeper
 - storage

--- a/charts/zookeeper-operator/README.md
+++ b/charts/zookeeper-operator/README.md
@@ -42,7 +42,7 @@ The following table lists the configurable parameters of the zookeeper-operator 
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
 | `image.repository` | Image repository | `pravega/zookeeper-operator` |
-| `image.tag` | Image tag | `0.2.11` |
+| `image.tag` | Image tag | `0.2.12` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `crd.create` | Create zookeeper CRD | `true` |
 | `rbac.create` | Create RBAC resources | `true` |

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -9,7 +9,7 @@ global:
 
 image:
   repository: pravega/zookeeper-operator
-  tag: 0.2.11
+  tag: 0.2.12
   pullPolicy: IfNotPresent
 
 ## Install RBAC roles and bindings.

--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: zookeeper
 description: Zookeeper Helm chart for Kubernetes
-version: 0.2.11
-appVersion: 0.2.11
+version: 0.2.12
+appVersion: 0.2.12
 keywords:
 - zookeeper
 - storage

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -55,7 +55,7 @@ The following table lists the configurable parameters of the zookeeper chart and
 | ----- | ----------- | ------ |
 | `replicas` | Expected size of the zookeeper cluster (valid range is from 1 to 7) | `3` |
 | `image.repository` | Image repository | `pravega/zookeeper` |
-| `image.tag` | Image tag | `0.2.11` |
+| `image.tag` | Image tag | `0.2.12` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `domainName` | External host name appended for dns annotation | |
 | `kubernetesClusterDomain` | Domain of the kubernetes cluster | `cluster.local` |

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -2,7 +2,7 @@ replicas: 3
 
 image:
   repository: pravega/zookeeper
-  tag: 0.2.11
+  tag: 0.2.12
   pullPolicy: IfNotPresent
 
 domainName:

--- a/deploy/all_ns/operator.yaml
+++ b/deploy/all_ns/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: zookeeper-operator
           # Replace this with the built image name
-          image: pravega/zookeeper-operator:0.2.11
+          image: pravega/zookeeper-operator:0.2.12
           ports:
           - containerPort: 60000
             name: metrics

--- a/deploy/cr/ECS/zookeeper_v1beta1_zookeepercluster_cr.yaml
+++ b/deploy/cr/ECS/zookeeper_v1beta1_zookeepercluster_cr.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 3
   image:
     repository: pravega/zookeeper
-    tag: 0.2.11
+    tag: 0.2.12
   storageType: persistence
   persistence:
     reclaimPolicy: Retain

--- a/deploy/cr/pravega/zookeeper_v1beta1_zookeepercluster_cr.yaml
+++ b/deploy/cr/pravega/zookeeper_v1beta1_zookeepercluster_cr.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 3
   image:
     repository: pravega/zookeeper
-    tag: 0.2.11
+    tag: 0.2.12
   storageType: persistence
   persistence:
     reclaimPolicy: Delete

--- a/deploy/default_ns/operator.yaml
+++ b/deploy/default_ns/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: zookeeper-operator
           # Replace this with the built image name
-          image: pravega/zookeeper-operator:0.2.11
+          image: pravega/zookeeper-operator:0.2.12
           ports:
           - containerPort: 60000
             name: metrics

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types.go
@@ -26,7 +26,7 @@ const (
 
 	// DefaultZkContainerVersion is the default tag used for for the zookeeper
 	// container
-	DefaultZkContainerVersion = "0.2.11"
+	DefaultZkContainerVersion = "0.2.12"
 
 	// DefaultZkContainerPolicy is the default container pull policy used
 	DefaultZkContainerPolicy = "Always"

--- a/pkg/apis/zookeeper/v1beta1/zookeepercluster_types_test.go
+++ b/pkg/apis/zookeeper/v1beta1/zookeepercluster_types_test.go
@@ -75,7 +75,7 @@ var _ = Describe("ZookeeperCluster Types", func() {
 			})
 
 			It("Checking tostring() function", func() {
-				Ω(z.Spec.Image.ToString()).To(Equal("pravega/zookeeper:0.2.11"))
+				Ω(z.Spec.Image.ToString()).To(Equal("pravega/zookeeper:0.2.12"))
 			})
 
 		})


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Updates the zookeeper and zookeeper operator version within the charts and the manifest files

### Purpose of the change
Fixes #371 

### What the code does
Changes the default version of the zookeeper operator and zookeeper cluster to 0.2.12

### How to verify it
Should deploy the latest version of zookeeper operator as well as zookeeper cluster i.e. 0.2.12
