### PR TITLE
Prevent status updates from triggering reconcile loops

### DIFF
--- a/pkg/controller/zookeepercluster/zookeepercluster_controller.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/operator-framework/operator-sdk/pkg/predicate"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -71,7 +72,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// Watch for changes to primary resource ZookeeperCluster
 	err = c.Watch(&source.Kind{Type: &zookeeperv1beta1.ZookeeperCluster{}},
-		&handler.EnqueueRequestForObject{})
+		&handler.EnqueueRequestForObject{}, predicate.GenerationChangedPredicate{})
 	if err != nil {
 		return err
 	}
@@ -79,7 +80,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	err = c.Watch(&source.Kind{Type: &appsv1.StatefulSet{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &zookeeperv1beta1.ZookeeperCluster{},
-	})
+	}, predicate.GenerationChangedPredicate{})
 	if err != nil {
 		return err
 	}
@@ -87,7 +88,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	err = c.Watch(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &zookeeperv1beta1.ZookeeperCluster{},
-	})
+	}, predicate.GenerationChangedPredicate{})
 	if err != nil {
 		return err
 	}
@@ -95,7 +96,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &zookeeperv1beta1.ZookeeperCluster{},
-	})
+	}, predicate.GenerationChangedPredicate{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Change log description

Prevents the operator from reconciling every time it updates the status. 

### Purpose of the change

Fixes #389 


### What the code does

I noticed in the logs that the reconcile loop was running none stop, some times with only a few milisecond pauses. In my own operators I have had the same problem with updating the status object triggering a loop, if you use a predicate to filter events you can prevent that from happening. The build in [predicate.GenerationChangedPredicate{}](https://github.com/operator-framework/operator-sdk/blob/v0.19.4/pkg/predicate/predicate.go#L39) does a good job at preventing that and still allowing through other changes. 

### How to verify it

Start up the operator, create a cluster and it should reconcile once every 30seconds. 
