### PR TITLE
Issue 394: Allow to set pod annotations in post-install-upgrade job in helm chart

### DIFF
--- a/charts/zookeeper/templates/post-install-upgrade-hooks.yaml
+++ b/charts/zookeeper/templates/post-install-upgrade-hooks.yaml
@@ -96,6 +96,10 @@ spec:
   template:
     metadata:
       name: {{ template "zookeeper.fullname" . }}-post-install-upgrade
+      {{- if .Values.hooks.pod.annotations }}
+      annotations:
+{{ toYaml .Values.hooks.pod.annotations | indent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "zookeeper.fullname" . }}-post-install-upgrade
       restartPolicy: Never

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -95,6 +95,8 @@ hooks:
     repository: lachlanevenson/k8s-kubectl
     tag: v1.16.10
   backoffLimit: 10
+  pod:
+    annotations: {}
 
 containers: []
 volumes: []


### PR DESCRIPTION
Signed-off-by: Petr Kohut <petr.kohut@williamhill.co.uk>

### Change log description

- Adds an option to add pod annotations to the zookeeper-post-install-upgrade K8s job.

### Purpose of the change

Fixes #394 

### What the code does

- adds additional property into values.yaml allowing to set pod annotations on post-install-upgrade job
- updates the K8s manifest of post-install-upgrade Job

### How to verify it
```sh
helm template test . --set hooks.pod.annotations.test=hello
```
