### PR TITLE
[Issue-400] add disableFinalizer flag

### DIFF
--- a/charts/zookeeper-operator/README.md
+++ b/charts/zookeeper-operator/README.md
@@ -56,3 +56,5 @@ The following table lists the configurable parameters of the zookeeper-operator 
 | `additionalEnv` | Additional Environment Variables | `[]` |
 | `additionalSidecars` | Additional Sidecars Configuration | `[]` |
 | `additionalVolumes` | Additional volumes required for sidecars | `[]` |
+| `disableFinalizer` | Disable finalizer for zookeeper clusters, PVCs clean-up will be skipped.| `false` |
+

--- a/charts/zookeeper-operator/templates/operator.yaml
+++ b/charts/zookeeper-operator/templates/operator.yaml
@@ -34,6 +34,10 @@ spec:
           name: metrics
         command:
         - zookeeper-operator
+        {{- if .Values.disableFinalizer }}
+        args:
+        - -disableFinalizer
+        {{- end }}
         env:
         - name: WATCH_NAMESPACE
           value: "{{ .Values.watchNamespace }}"

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -73,3 +73,5 @@ additionalVolumes: {}
 #   emptyDir: {}
 # - name: volume2
 #   emptyDir: {}
+
+disableFinalizer: false

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -36,12 +36,15 @@ import (
 )
 
 var (
-	log         = logf.Log.WithName("cmd")
-	versionFlag bool
+	log              = logf.Log.WithName("cmd")
+	versionFlag      bool
+	disableFinalizer bool
 )
 
 func init() {
 	flag.BoolVar(&versionFlag, "version", false, "Show version and quit")
+	flag.BoolVar(&disableFinalizer, "disableFinalizer", false,
+		"Disable finalizers for zookeeperclusters. Use this flag with awareness of the consequences")
 }
 
 func printVersion() {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,6 +24,7 @@ import (
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/pravega/zookeeper-operator/pkg/apis"
 	"github.com/pravega/zookeeper-operator/pkg/controller"
+	zkConfig "github.com/pravega/zookeeper-operator/pkg/controller/config"
 	"github.com/pravega/zookeeper-operator/pkg/utils"
 	"github.com/pravega/zookeeper-operator/pkg/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -36,14 +37,13 @@ import (
 )
 
 var (
-	log              = logf.Log.WithName("cmd")
-	versionFlag      bool
-	disableFinalizer bool
+	log         = logf.Log.WithName("cmd")
+	versionFlag bool
 )
 
 func init() {
 	flag.BoolVar(&versionFlag, "version", false, "Show version and quit")
-	flag.BoolVar(&disableFinalizer, "disableFinalizer", false,
+	flag.BoolVar(&zkConfig.DisableFinalizer, "disableFinalizer", false,
 		"Disable finalizers for zookeeperclusters. Use this flag with awareness of the consequences")
 }
 

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package config
+
+// DisableFinalizer disables the finalizers for zookeeper clusters and
+// skips the pvc deletion phase when zookeeper cluster get deleted.
+// This is useful when operator deletion may happen before zookeeper clusters deletion.
+// NOTE: enabling this flag with caution! It causes pvc of zk undeleted.
+var DisableFinalizer bool

--- a/pkg/controller/zookeepercluster/zookeepercluster_controller.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller.go
@@ -17,11 +17,11 @@ import (
 	"time"
 
 	"github.com/operator-framework/operator-sdk/pkg/predicate"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
+	"github.com/pravega/zookeeper-operator/pkg/controller/config"
 	"github.com/pravega/zookeeper-operator/pkg/utils"
 	"github.com/pravega/zookeeper-operator/pkg/yamlexporter"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/go-logr/logr"
 	zookeeperv1beta1 "github.com/pravega/zookeeper-operator/pkg/apis/zookeeper/v1beta1"
@@ -733,7 +733,7 @@ func (r *ReconcileZookeeperCluster) reconcileFinalizers(instance *zookeeperv1bet
 		return nil
 	}
 	if instance.DeletionTimestamp.IsZero() {
-		if !utils.ContainsString(instance.ObjectMeta.Finalizers, utils.ZkFinalizer) {
+		if !utils.ContainsString(instance.ObjectMeta.Finalizers, utils.ZkFinalizer) && !config.DisableFinalizer {
 			instance.ObjectMeta.Finalizers = append(instance.ObjectMeta.Finalizers, utils.ZkFinalizer)
 			if err = r.client.Update(context.TODO(), instance); err != nil {
 				return err

--- a/pkg/controller/zookeepercluster/zookeepercluster_controller_test.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/pravega/zookeeper-operator/pkg/apis/zookeeper/v1beta1"
+	"github.com/pravega/zookeeper-operator/pkg/controller/config"
 	"github.com/pravega/zookeeper-operator/pkg/zk"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -605,6 +606,32 @@ var _ = Describe("ZookeeperCluster Controller", func() {
 				err = r.reconcileFinalizers(z)
 			})
 			It("should not raise an error", func() {
+				Ω(err).To(BeNil())
+			})
+		})
+
+		Context("reconcileFinalizers", func() {
+			var (
+				cl  client.Client
+				err error
+			)
+			BeforeEach(func() {
+				z.WithDefaults()
+				z.Spec.Persistence = nil
+				cl = fake.NewFakeClient(z)
+			})
+			It("should have 1 finalizer, should not raise an error", func() {
+				config.DisableFinalizer = false
+				r = &ReconcileZookeeperCluster{client: cl, scheme: s, zkClient: mockZkClient}
+				err = r.reconcileFinalizers(z)
+				Expect(z.ObjectMeta.Finalizers).To(HaveLen(1))
+				Ω(err).To(BeNil())
+			})
+			It("should have 0 finalizer, should not raise an error", func() {
+				config.DisableFinalizer = true
+				r = &ReconcileZookeeperCluster{client: cl, scheme: s, zkClient: mockZkClient}
+				err = r.reconcileFinalizers(z)
+				Expect(z.ObjectMeta.Finalizers).To(HaveLen(0))
 				Ω(err).To(BeNil())
 			})
 		})


### PR DESCRIPTION


### Change log description

add DisableFinalizer config and skip adding zkFinalziers when set it to true.

### Purpose of the change

Issue-400

### What the code does

skip adding zkFinalziers when DisableFinalizer set to true.

### How to verify it

Set disableFinalizer to true in values and deploy zookeeper operator, the deployed zookeeper  clusters should have the finalizers as empty.And when delete operator before deleting zookeeper  clusters, zk cluster deletion will not be blocked.
