### PR TITLE
Issue#398 that decreasing replicas will make zookeeper unrecoverable when zookeeper not running.

### DIFF
--- a/pkg/controller/zookeepercluster/zookeepercluster_controller_test.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller_test.go
@@ -60,8 +60,12 @@ func (client *MockZookeeperClient) NodeExists(zNodePath string) (version int32, 
 	return 0, nil
 }
 
-func (client *MockZookeeperClient) ReconfigToRemove(leaving []string) (err error) {
+func (client *MockZookeeperClient) IncReconfig(joining []string, leaving []string, version int64) (err error) {
 	return nil
+}
+
+func (client *MockZookeeperClient) GetConfig() (config string, version int32, err error) {
+	return "", 0, nil
 }
 
 func (client *MockZookeeperClient) Close() {

--- a/pkg/controller/zookeepercluster/zookeepercluster_controller_test.go
+++ b/pkg/controller/zookeepercluster/zookeepercluster_controller_test.go
@@ -60,6 +60,10 @@ func (client *MockZookeeperClient) NodeExists(zNodePath string) (version int32, 
 	return 0, nil
 }
 
+func (client *MockZookeeperClient) ReconfigToRemove(leaving []string) (err error) {
+	return nil
+}
+
 func (client *MockZookeeperClient) Close() {
 	return
 }

--- a/pkg/zk/zookeeper_client.go
+++ b/pkg/zk/zookeeper_client.go
@@ -24,13 +24,17 @@ type ZookeeperClient interface {
 	CreateNode(*v1beta1.ZookeeperCluster, string) error
 	NodeExists(string) (int32, error)
 	UpdateNode(string, string, int32) error
-	ReconfigToRemove([]string) error
+	IncReconfig([]string, []string, int64) error
+	GetConfig() (string, int32, error)
 	Close()
 }
 
 type DefaultZookeeperClient struct {
 	conn *zk.Conn
 }
+
+// zookeeper configure path
+const ZOO_CONFIG_PATH = "/zookeeper/config"
 
 func (client *DefaultZookeeperClient) Connect(zkUri string) (err error) {
 	host := []string{zkUri}
@@ -75,11 +79,19 @@ func (client *DefaultZookeeperClient) NodeExists(zNodePath string) (version int3
 	return zNodeStat.Version, err
 }
 
-func (client *DefaultZookeeperClient) ReconfigToRemove(leaving []string) (err error) {
-	if _, err := client.conn.IncrementalReconfig(nil, leaving, -1); err != nil {
-		return fmt.Errorf("Failed to remove node:%s, err:%v", strings.Join(leaving, ","), err)
+func (client *DefaultZookeeperClient) IncReconfig(joining []string, leaving []string, version int64) (err error) {
+	if _, err := client.conn.IncrementalReconfig(joining, leaving, version); err != nil {
+		return fmt.Errorf("Failed to reconfig node:%s, err:%v", strings.Join(leaving, ","), err)
 	}
 	return nil
+}
+
+func (client *DefaultZookeeperClient) GetConfig() (config string, version int32, err error) {
+	data, stat, err := client.conn.Get(ZOO_CONFIG_PATH)
+	if err != nil {
+		return "", -1, fmt.Errorf("Get config %s error, err:%v", ZOO_CONFIG_PATH, err)
+	}
+	return string(data), stat.Version, nil
 }
 
 func (client *DefaultZookeeperClient) Close() {

--- a/pkg/zk/zookeeper_client.go
+++ b/pkg/zk/zookeeper_client.go
@@ -24,6 +24,7 @@ type ZookeeperClient interface {
 	CreateNode(*v1beta1.ZookeeperCluster, string) error
 	NodeExists(string) (int32, error)
 	UpdateNode(string, string, int32) error
+	ReconfigToRemove([]string) error
 	Close()
 }
 
@@ -72,6 +73,13 @@ func (client *DefaultZookeeperClient) NodeExists(zNodePath string) (version int3
 		return -1, fmt.Errorf("Znode exists check failed for path %s: %v", zNodePath, err)
 	}
 	return zNodeStat.Version, err
+}
+
+func (client *DefaultZookeeperClient) ReconfigToRemove(leaving []string) (err error) {
+	if _, err := client.conn.IncrementalReconfig(nil, leaving, -1); err != nil {
+		return fmt.Errorf("Failed to remove node:%s, err:%v", strings.Join(leaving, ","), err)
+	}
+	return nil
 }
 
 func (client *DefaultZookeeperClient) Close() {

--- a/pkg/zk/zookeeper_client_test.go
+++ b/pkg/zk/zookeeper_client_test.go
@@ -21,7 +21,7 @@ import (
 var _ = Describe("Zookeeper Client", func() {
 
 	Context("with a valid update of Service port", func() {
-		var err1, err2, err3, err4, err5 error
+		var err1, err2, err3, err4, err5, err6, err7 error
 		BeforeEach(func() {
 			z := &v1beta1.ZookeeperCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -36,6 +36,8 @@ var _ = Describe("Zookeeper Client", func() {
 			err5 = zkclient.CreateNode(z, "temp/tmp")
 			err3 = zkclient.UpdateNode("temp/tem/temp", "dasd", 2)
 			_, err4 = zkclient.NodeExists("temp")
+			_, _, err6 = zkclient.GetConfig()
+			err7 = zkclient.IncReconfig(nil, nil, -1)
 			zkclient.Close()
 		})
 		It("err1 should be nil", func() {
@@ -52,6 +54,12 @@ var _ = Describe("Zookeeper Client", func() {
 		})
 		It("err5 should be not nil", func() {
 			Ω(err5).ShouldNot(BeNil())
+		})
+		It("err6 should be not nil", func() {
+			Ω(err6).ShouldNot(BeNil())
+		})
+		It("err should be not nil", func() {
+			Ω(err7).ShouldNot(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
Change log description
Fixes the bug that decreasing replicas will make zookeeper unrecoverable when zookeeper not running.

Purpose of the change
Fixes #398

What the code does
Add protection for setting Stateful when zookeeper not running.
If zookeeper not running, we will prohibited to update replicas status until zookeeper resume.
When user decrease replicas value, it will remove node with reconfig firstly.
Keep do that remove node with reconfig on preStop before pod exit.

How to verify it
Create an cluster that size is 3 (kubectl create -f zk.yaml).
Wait all pod running, named: zk-0\zk-1\zk-2.
Delete zk-1\zk-2 pod, it make cluster of zookeeper unable to provide services.
"kubectl edit zk" that change replicas to 1 immediately.
Wait some time, replicas will decrease to 1.
Now, checking that:
Is zk-0 is all right?
