### PR TITLE
Add missing namespaces to pre-delete-hooks.yaml in zookeeper-operator chart

### DIFF
--- a/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
+++ b/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "1"
@@ -21,6 +22,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "1"
@@ -40,6 +42,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "1"
@@ -51,6 +54,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "1"
@@ -82,6 +86,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "2"

--- a/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
+++ b/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
-  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "1"
@@ -22,7 +21,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
-  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "1"


### PR DESCRIPTION
Signed-off-by: Darren Lau <panyuenlau@gmail.com>

### Change log description

Add missing namespaces to the resources in pre-delete-hooks.yaml within the zookeeper-operator chart

### Purpose of the change

Fixes #411

### What the code does

This PR adds the `namespace` field to the resources in the pre-delete-hooks.yaml

### How to verify it

The programmatic way (as described in the issue) of uninstalling the zookeeper-operator would have all the pre-delete-hooks resources created in the namespace that the helm release uses, and the uninstallation works fine