### PR TITLE
Issue 430: remove namespace from non-namespaced resources

### DIFF
--- a/charts/zookeeper-operator/templates/clusterrole.yaml
+++ b/charts/zookeeper-operator/templates/clusterrole.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "zookeeper-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "zookeeper-operator.commonLabels" . | indent 4 }}
 rules:

--- a/charts/zookeeper-operator/templates/clusterrolebinding.yaml
+++ b/charts/zookeeper-operator/templates/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "zookeeper-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "zookeeper-operator.commonLabels" . | indent 4 }}
 subjects:


### PR DESCRIPTION
### Change log description

Removes metadata.namespace from non-namespaced resources such as ClusterRole and ClusterRoleBinding.

### Purpose of the change

Fixes #430 

### What the code does

Removes `metadata.namespace` from non-namespaced resources
