### PR TITLE
Issue 432: zk operator pre delete hook fail in slow environments

### DIFF
--- a/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
+++ b/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
@@ -90,8 +90,7 @@ metadata:
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
 spec:
-  backoffLimit: 1
-  activeDeadlineSeconds: 20
+  backoffLimit: 6
   template:
     metadata:
       name: {{ template "zookeeper-operator.fullname" . }}-pre-delete

--- a/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
+++ b/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
@@ -100,6 +100,10 @@ spec:
       containers:
         - name: pre-delete-job
           image: "{{ .Values.hooks.image.repository }}:{{ .Values.hooks.image.tag }}"
+          {{- if .Values.hooks.securityContext }}
+          securityContext:
+{{ toYaml .Values.hooks.securityContext | indent 12 }}
+          {{- end }}
           command:
             - /scripts/pre-delete.sh
           volumeMounts:

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -56,7 +56,11 @@ hooks:
   backoffLimit: 10
   image:
     repository: lachlanevenson/k8s-kubectl
-    tag: v1.16.10
+    tag: v1.23.2
+  securityContext: {}
+  #  runAsUser: 1001
+  #  runAsGroup: 1001
+
   ## Whether to create pre-delete hook which ensures that
   ## the operator cannot be deleted till the zookeeper cluster
   ## custom resources have been cleaned up

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -93,7 +93,7 @@ ephemeral:
 hooks:
   image:
     repository: lachlanevenson/k8s-kubectl
-    tag: v1.16.10
+    tag: v1.23.2
   backoffLimit: 10
   pod:
     annotations: {}


### PR DESCRIPTION
### Change log description

Currently in the zookeeper-operator charts' pre delete hook-script, the `activeDeadlineSeconds` is set to 20 which causes job to fail in slow environments. Need to remove the `activeDeadlineSeconds` and increase the `backoffLimit`

### Purpose of the change

Fixes #432

### What the code does

Removes the `activeDeadlineSeconds` from the pre delete hook script of the zk-operator chart and add Security Context . Also bump the `backoffLimit` to 6 and update the `hooks.image.tag` in values.yaml file

### How to verify it

Verified by Installing the SDP on an Openshift cluster
