### PR TITLE
Issue 440: Added support to run zookeeper operator as non-root

### DIFF
--- a/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
+++ b/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
@@ -94,6 +94,10 @@ spec:
       containers:
       - name: post-install-upgrade-job
         image: "{{ .Values.hooks.image.repository }}:{{ .Values.hooks.image.tag }}"
+        {{- if .Values.hooks.securityContext }}
+        securityContext:
+{{ toYaml .Values.hooks.securityContext | indent 10 }}
+        {{- end }}
         command:
           - /scripts/validations.sh
         volumeMounts:

--- a/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
+++ b/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
@@ -90,8 +90,7 @@ metadata:
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
 spec:
-  backoffLimit: 1
-  activeDeadlineSeconds: 20
+  backoffLimit: 6
   template:
     metadata:
       name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
@@ -101,6 +100,10 @@ spec:
       containers:
         - name: pre-delete-job
           image: "{{ .Values.hooks.image.repository }}:{{ .Values.hooks.image.tag }}"
+          {{- if .Values.hooks.securityContext }}
+          securityContext:
+{{ toYaml .Values.hooks.securityContext | indent 12 }}
+          {{- end }}
           command:
             - /scripts/pre-delete.sh
           volumeMounts:

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -12,6 +12,10 @@ image:
   tag: 0.2.13
   pullPolicy: IfNotPresent
 
+securityContext: {}
+#  runAsUser: 1001
+#  runAsGroup: 1001
+
 ## Additional labels to be added to resources
 labels: {}
 
@@ -56,11 +60,15 @@ hooks:
   backoffLimit: 10
   image:
     repository: lachlanevenson/k8s-kubectl
-    tag: v1.16.10
+    tag: v1.23.2
   ## Whether to create pre-delete hook which ensures that
   ## the operator cannot be deleted till the zookeeper cluster
   ## custom resources have been cleaned up
   delete: true
+  securityContext: {}
+  #  runAsUser: 1001
+  #  runAsGroup: 1001
+
 
 ## Additional Sidecars Configuration.
 additionalSidecars: {}

--- a/charts/zookeeper/templates/post-install-upgrade-hooks.yaml
+++ b/charts/zookeeper/templates/post-install-upgrade-hooks.yaml
@@ -124,6 +124,10 @@ spec:
       containers:
       - name: post-install-upgrade-job
         image: "{{ .Values.hooks.image.repository }}:{{ .Values.hooks.image.tag }}"
+        {{- if .Values.hooks.securityContext }}
+        securityContext:
+{{ toYaml .Values.hooks.securityContext | indent 10 }}
+        {{- end }}
         command:
           - /scripts/validations.sh
         volumeMounts:

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -69,7 +69,7 @@ config:
   # autoPurgePurgeInterval: 1
   # quorumListenOnAllIPs: false
   # additionalConfig: {}
-  
+
 ## configure the storage type
 ## accepted values : persistence/ephemeral
 ## default option is persistence
@@ -93,7 +93,10 @@ ephemeral:
 hooks:
   image:
     repository: lachlanevenson/k8s-kubectl
-    tag: v1.16.10
+    tag: v1.23.2
+    securityContext: {}
+    #  runAsUser: 1001
+    #  runAsGroup: 1001
   backoffLimit: 10
   pod:
     annotations: {}


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

Made changes in operator charts to configure security context.
Updated hook image to `1.23.2`
Added options in hooks to configure security context.
Active Delay seconds is removed in `pre-delete-hooks`

### Purpose of the change

 Fixes #440

### What the code does

Provide support  to run zookeeper-operator as non-root user

### How to verify it

Verify able to run zookeeper-operator as non root user
