### PR TITLE
Issue#457 BUG: metrics http port not use zk helm chart values

### DIFF
--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -258,7 +258,7 @@ func makeZkConfigString(z *v1beta1.ZookeeperCluster) string {
 		"reconfigEnabled=true\n" +
 		"skipACL=yes\n" +
 		"metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider\n" +
-		"metricsProvider.httpPort=7000\n" +
+		"metricsProvider.httpPort=" + strconv.Itoa(int(ports.Metrics)) + "\n" +
 		"metricsProvider.exportJvmInfo=true\n" +
 		"initLimit=" + strconv.Itoa(z.Spec.Conf.InitLimit) + "\n" +
 		"syncLimit=" + strconv.Itoa(z.Spec.Conf.SyncLimit) + "\n" +


### PR DESCRIPTION
### Change log description

The zk configuration was generated without using the provided metrics port configuration
``` golang
func makeZkConfigString(z *v1beta1.ZookeeperCluster) string {
	ports := z.ZookeeperPorts()

	var zkConfig = ""
	for key, value := range z.Spec.Conf.AdditionalConfig {
		zkConfig = zkConfig + fmt.Sprintf("%s=%s\n", key, value)
	}
	return zkConfig + "4lw.commands.whitelist=cons, envi, conf, crst, srvr, stat, mntr, ruok\n" +
		"dataDir=/data\n" +
		"standaloneEnabled=false\n" +
		"reconfigEnabled=true\n" +
		"skipACL=yes\n" +
		"metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider\n" +
		"metricsProvider.httpPort=7000\n" +
		"metricsProvider.exportJvmInfo=true\n" +
		"initLimit=" + strconv.Itoa(z.Spec.Conf.InitLimit) + "\n" +
		"syncLimit=" + strconv.Itoa(z.Spec.Conf.SyncLimit) + "\n" +
		"tickTime=" + strconv.Itoa(z.Spec.Conf.TickTime) + "\n" +
		"globalOutstandingLimit=" + strconv.Itoa(z.Spec.Conf.GlobalOutstandingLimit) + "\n" +
		"preAllocSize=" + strconv.Itoa(z.Spec.Conf.PreAllocSize) + "\n" +
		"snapCount=" + strconv.Itoa(z.Spec.Conf.SnapCount) + "\n" +
		"commitLogCount=" + strconv.Itoa(z.Spec.Conf.CommitLogCount) + "\n" +
		"snapSizeLimitInKb=" + strconv.Itoa(z.Spec.Conf.SnapSizeLimitInKb) + "\n" +
		"maxCnxns=" + strconv.Itoa(z.Spec.Conf.MaxCnxns) + "\n" +
		"maxClientCnxns=" + strconv.Itoa(z.Spec.Conf.MaxClientCnxns) + "\n" +
		"minSessionTimeout=" + strconv.Itoa(z.Spec.Conf.MinSessionTimeout) + "\n" +
		"maxSessionTimeout=" + strconv.Itoa(z.Spec.Conf.MaxSessionTimeout) + "\n" +
		"autopurge.snapRetainCount=" + strconv.Itoa(z.Spec.Conf.AutoPurgeSnapRetainCount) + "\n" +
		"autopurge.purgeInterval=" + strconv.Itoa(z.Spec.Conf.AutoPurgePurgeInterval) + "\n" +
		"quorumListenOnAllIPs=" + strconv.FormatBool(z.Spec.Conf.QuorumListenOnAllIPs) + "\n" +
		"admin.serverPort=" + strconv.Itoa(int(ports.AdminServer)) + "\n" +
		"dynamicConfigFile=/data/zoo.cfg.dynamic\n"
}
```

### Purpose of the change

issue#457

### What the code does

using the provided metrics port configuration

### How to verify it

check zk configuration



