### PR TITLE
Issue 467: Fixing Leader election failure

### DIFF
--- a/charts/zookeeper-operator/templates/operator.yaml
+++ b/charts/zookeeper-operator/templates/operator.yaml
@@ -32,11 +32,13 @@ spec:
       - name: {{ template "zookeeper-operator.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 6000
+          name: metrics
         command:
         - zookeeper-operator
-        args:
-          - "--metrics-bind-address=127.0.0.1:6000"
         {{- if .Values.disableFinalizer }}
+        args:
         - -disableFinalizer
         {{- end }}
         env:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -17,8 +17,9 @@ spec:
         - name: zookeeper-operator
           # Replace this with the built image name
           image: pravega/zookeeper-operator:0.2.13
-          args:
-            - "--metrics-bind-address=127.0.0.1:60000"
+          ports:
+          - containerPort: 60000
+            name: metrics
           command:
           - zookeeper-operator
           imagePullPolicy: Always


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

use the customized leader.Become function as it handles certain pre-checks

### Purpose of the change

Fixes #467

### What the code does
When the operator-sdk version is upgraded, the customized leader function got replaced with operator-lib leader.Become function. So this PR reverts that and use customized function.

Also modifying operator.yaml to fix compatibility issues

### How to verify it

All e2e should pass
