### PR TITLE
Use zookeeper 3.7.0 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The project is currently alpha. While no breaking API changes are currently plan
 
 ### Overview
 
-This operator runs a Zookeeper 3.8.0 cluster, and uses Zookeeper dynamic reconfiguration to handle node membership.
+This operator runs a Zookeeper 3.7.0 cluster, and uses Zookeeper dynamic reconfiguration to handle node membership.
 
 The operator itself is built with the [Operator framework](https://github.com/operator-framework/operator-sdk).
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ COPY zu /zu
 WORKDIR /zu
 RUN ./gradlew --console=verbose --info shadowJar
 
-FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}zookeeper:3.8.0
+FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}zookeeper:3.7.0
 COPY bin /usr/local/bin
 RUN chmod +x /usr/local/bin/*
 COPY --from=0 /zu/build/libs/zu.jar /opt/libs/

--- a/docker/zu/build.gradle.kts
+++ b/docker/zu/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    implementation("org.apache.zookeeper:zookeeper:3.8.0")
+    implementation("org.apache.zookeeper:zookeeper:3.7.0")
 }
 
 tasks.withType<ShadowJar>() {


### PR DESCRIPTION
Version 3.8.0 is not stable enough for usage, downgrading to
use 3.7.0.

Fixes: #470

### How to verify it
Run `make build-zk-image` and execute e2e tests with newly build image