### PR TITLE
Issue 482: Reevaluating number of client connections dynamically in the teardown script

### DIFF
--- a/docker/bin/zookeeperTeardown.sh
+++ b/docker/bin/zookeeperTeardown.sh
@@ -20,8 +20,8 @@ LOG4J_CONF=/conf/log4j-quiet.properties
 
 # Wait for client connections to drain. Kubernetes will wait until the confiugred
 # "terminationGracePeriodSeconds" before focibly killing the container
-CONN_COUNT=`echo cons | nc localhost 2181 | grep -v "^$" |grep -v "/127.0.0.1:" | wc -l`
 for (( i = 0; i < 6; i++ )); do
+  CONN_COUNT=`echo cons | nc localhost 2181 | grep -v "^$" |grep -v "/127.0.0.1:" | wc -l`
   if [[ "$CONN_COUNT" -gt 0 ]]; then
     echo "$CONN_COUNT non-local connections still connected."
     sleep 5


### PR DESCRIPTION
Signed-off-by: Nishant Gupta <Nishant_Gupta3@dell.com>

### Change log description
Currently the CONN_COUNT variable is only evaluated once in the zookeeperTeardown.sh script 
As a result, the loop would always take 30 seconds if there were client connections present when the script started to run, and ZK pod would terminate with 137 error code with the default termination grace period set to 30s.  Need to make sure CONN_COUNT gets reevaluated every cycle and allows the code to break out of the loop earlier.

### Purpose of the change

Fixes #482

### What the code does

Moves the CONN_COUNT variable inside the for loop

### How to verify it

All e2e should pass
