### PR TITLE
upgrading zookeeper to 3.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The project is currently alpha. While no breaking API changes are currently plan
 
 ### Overview
 
-This operator runs a Zookeeper 3.7.0 cluster, and uses Zookeeper dynamic reconfiguration to handle node membership.
+This operator runs a Zookeeper 3.7.1 cluster, and uses Zookeeper dynamic reconfiguration to handle node membership.
 
 The operator itself is built with the [Operator framework](https://github.com/operator-framework/operator-sdk).
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ COPY zu /zu
 WORKDIR /zu
 RUN ./gradlew --console=verbose --info shadowJar
 
-FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}zookeeper:3.7.0
+FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}zookeeper:3.7.1
 COPY bin /usr/local/bin
 RUN chmod +x /usr/local/bin/*
 COPY --from=0 /zu/build/libs/zu.jar /opt/libs/

--- a/docker/zu/build.gradle.kts
+++ b/docker/zu/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    implementation("org.apache.zookeeper:zookeeper:3.7.0")
+    implementation("org.apache.zookeeper:zookeeper:3.7.1")
 }
 
 tasks.withType<ShadowJar>() {


### PR DESCRIPTION
Signed-off-by: Amit-Singh40 <amit.singh30@dell.com>

### Change log description

Upgraded the zookeeper version to 3.7.1 to fix vulnerabilities in 3.7.0

### Purpose of the change
Fixes #484 


### What the code does

Upgrades the zookeeper to 3.7.1

### How to verify it

Perform jenkins tests: Pravega_ZookeeperOperator, Pravega_Zookeeper_Upgrade and Pravega_ZookeeperOperator_E2E and github build.
