### PR TITLE
Fix #474: Svc Annotations created but not updated

### DIFF
--- a/pkg/zk/synchronizers.go
+++ b/pkg/zk/synchronizers.go
@@ -26,6 +26,7 @@ func SyncStatefulSet(curr *appsv1.StatefulSet, next *appsv1.StatefulSet) {
 func SyncService(curr *v1.Service, next *v1.Service) {
 	curr.Spec.Ports = next.Spec.Ports
 	curr.Spec.Type = next.Spec.Type
+	curr.SetAnnotations(next.GetAnnotations())
 }
 
 // SyncConfigMap synchronizes a configmap with an updated spec and validates it


### PR DESCRIPTION
### Change log description

- Updating zk.SyncService to update annotations of services
- Fixed #474
- Now service annotations can be configured by user at runtime

### Purpose of the change

Fix #474, now service annotations are not only created but also updated.

### What the code does

We added one line of code in the function to update annotations.
```golang
curr.SetAnnotations(next.GetAnnotations())
```

### How to verify it
1. Build the image and deploy the operator
2. Deploy a zookeeper instance with no annotations specified
    ```YAML
    apiVersion: zookeeper.pravega.io/v1beta1
    kind: ZookeeperCluster
    metadata:
      name: zookeeper
    spec:
      replicas: 3
    ```
3. Execute `kubectl get svc/zookeeper-headless -o yaml` and observe that this service does not have any annotations.
    ```YAML
    apiVersion: v1
    kind: Service
    metadata:
      creationTimestamp: "2022-08-01T21:56:06Z"
      labels:
        app: zookeeper
        headless: "true"
        owner-rv: "1474"
        release: zookeeper
      name: zookeeper-headless
      namespace: default
      ownerReferences:
      - apiVersion: zookeeper.pravega.io/v1beta1
    ...
    ```

4. Now, update this zookeeper instance by adding `domainName: hgvkbmxwtg` to our CR.
    ```YAML
    apiVersion: zookeeper.pravega.io/v1beta1
    kind: ZookeeperCluster
    metadata:
      name: zookeeper
    spec:
      domainName: hgvkbmxwtg
      replicas: 3
    ```

5. Execute `kubectl get sec/zookeeper-headless -o yaml` and observe that this service now has the expected annotation.
    ```bash
    $ kubectl get svc/zookeeper-headless -o yaml
    apiVersion: v1
    kind: Service
    metadata:
      annotations:
        external-dns.alpha.kubernetes.io/hostname: zookeeper-headless.hgvkbmxwtg.
      creationTimestamp: "2022-08-01T21:56:06Z"
      labels:
        app: zookeeper
        headless: "true"
        owner-rv: "1474"
        release: zookeeper
      name: zookeeper-headless
      namespace: default
      ownerReferences:
      - apiVersion: zookeeper.pravega.io/v1beta1
    ...
    ``` 