### PR TITLE
Adds nodeSelector, affinity and tolerations to the pre-delete hook Job

### DIFF
--- a/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
+++ b/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
@@ -115,4 +115,16 @@ spec:
           configMap:
             name: {{ template "zookeeper-operator.fullname" . }}-pre-delete
             defaultMode: 0555
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
make delete Job respect scheduling choices

### Change log description

Makes the delete job respect node scheduling the same as the post install hooks do. Without this, it fails in a mixed windows/linux cluster.

### Purpose of the change

Fixes https://github.com/pravega/zookeeper-operator/issues/518
Fixes https://github.com/apache/solr-operator/issues/382

### What the code does

Adds a node selector to control pre-delete Job scheduling

### How to verify it

Deploy and remove. See that it schedules where you expect it to.
