### PR TITLE
Adjust behavior for pod labels

### DIFF
--- a/api/v1beta1/zookeepercluster_types.go
+++ b/api/v1beta1/zookeepercluster_types.go
@@ -82,8 +82,9 @@ type ZookeeperClusterSpec struct {
 	// Image is the  container image. default is zookeeper:0.2.10
 	Image ContainerImage `json:"image,omitempty"`
 
-	// Labels specifies the labels to attach to pods the operator creates for
-	// the zookeeper cluster.
+	// Labels specifies the labels to attach to all resources the operator
+	// creates for the zookeeper cluster, including StatefulSet, Pod,
+	// PersistentVolumeClaim, Service, ConfigMap, et al.
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// Replicas is the expected size of the zookeeper cluster.
@@ -433,8 +434,8 @@ func (c *ContainerImage) ToString() string {
 // PodPolicy defines the common pod configuration for Pods, including when used
 // in deployments, stateful-sets, etc.
 type PodPolicy struct {
-	// Labels specifies the labels to attach to pods the operator creates for
-	// the zookeeper cluster.
+	// Labels specifies the labels to attach to pods the operator creates for the
+	// zookeeper cluster. Overrides any values specified in Spec.Labels.
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// NodeSelector specifies a map of key-value pairs. For the pod to be

--- a/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
+++ b/charts/zookeeper-operator/templates/zookeeper.pravega.io_zookeeperclusters_crd.yaml
@@ -2684,8 +2684,9 @@ spec:
               labels:
                 additionalProperties:
                   type: string
-                description: Labels specifies the labels to attach to pods the operator
-                  creates for the zookeeper cluster.
+                description: Labels specifies the labels to attach to all resources
+                  the operator creates for the zookeeper cluster, including StatefulSet,
+                  Pod, PersistentVolumeClaim, Service, ConfigMap, et al.
                 type: object
               maxUnavailableReplicas:
                 description: MaxUnavailableReplicas defines the MaxUnavailable Replicas
@@ -3875,7 +3876,8 @@ spec:
                     additionalProperties:
                       type: string
                     description: Labels specifies the labels to attach to pods the
-                      operator creates for the zookeeper cluster.
+                      operator creates for the zookeeper cluster. Overrides any values
+                      specified in Spec.Labels.
                     type: object
                   nodeSelector:
                     additionalProperties:

--- a/config/crd/bases/zookeeper.pravega.io_zookeeperclusters.yaml
+++ b/config/crd/bases/zookeeper.pravega.io_zookeeperclusters.yaml
@@ -2683,8 +2683,9 @@ spec:
               labels:
                 additionalProperties:
                   type: string
-                description: Labels specifies the labels to attach to pods the operator
-                  creates for the zookeeper cluster.
+                description: Labels specifies the labels to attach to all resources
+                  the operator creates for the zookeeper cluster, including StatefulSet,
+                  Pod, PersistentVolumeClaim, Service, ConfigMap, et al.
                 type: object
               maxUnavailableReplicas:
                 description: MaxUnavailableReplicas defines the MaxUnavailable Replicas
@@ -3874,7 +3875,8 @@ spec:
                     additionalProperties:
                       type: string
                     description: Labels specifies the labels to attach to pods the
-                      operator creates for the zookeeper cluster.
+                      operator creates for the zookeeper cluster. Overrides any values
+                      specified in Spec.Labels.
                     type: object
                   nodeSelector:
                     additionalProperties:

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -91,6 +91,7 @@ func MakeStatefulSet(z *v1beta1.ZookeeperCluster) *appsv1.StatefulSet {
 					GenerateName: z.GetName(),
 					Labels: mergeLabels(
 						z.Spec.Labels,
+						z.Spec.Pod.Labels,
 						map[string]string{
 							"app":  z.GetName(),
 							"kind": "ZookeeperMember",


### PR DESCRIPTION
### Change log description

Pod labels from the Spec.Pod.Labels were previously not propagated to the StatefulSet.Template.

### Purpose of the change

Resolves #511

### What the code does

- Adds the Spec.Pod.Labels to the creation of the StatefulSet template
- Adds docs to note the differences between the two Label locations in the ZookeeperCluster CRD and denotes priority order

### How to verify it

- Add labels to the Spec.Pod.Labels and expect to have it show up in the pod labels