### PR TITLE
feat: Replace deprecated policy/v1beta1 PDB API

### DIFF
--- a/controllers/zookeepercluster_controller.go
+++ b/controllers/zookeepercluster_controller.go
@@ -15,19 +15,19 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pravega/zookeeper-operator/pkg/controller/config"
-	"github.com/pravega/zookeeper-operator/pkg/utils"
-	"github.com/pravega/zookeeper-operator/pkg/yamlexporter"
-	"github.com/pravega/zookeeper-operator/pkg/zk"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/pravega/zookeeper-operator/pkg/controller/config"
+	"github.com/pravega/zookeeper-operator/pkg/utils"
+	"github.com/pravega/zookeeper-operator/pkg/yamlexporter"
+	"github.com/pravega/zookeeper-operator/pkg/zk"
+
 	"github.com/go-logr/logr"
-	zookeeperv1beta1 "github.com/pravega/zookeeper-operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -38,6 +38,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	zookeeperv1beta1 "github.com/pravega/zookeeper-operator/api/v1beta1"
 )
 
 // ReconcileTime is the delay between reconciliations
@@ -467,7 +469,7 @@ func (r *ZookeeperClusterReconciler) reconcilePodDisruptionBudget(instance *zook
 	if err = controllerutil.SetControllerReference(instance, pdb, r.Scheme); err != nil {
 		return err
 	}
-	foundPdb := &policyv1beta1.PodDisruptionBudget{}
+	foundPdb := &policyv1.PodDisruptionBudget{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{
 		Name:      pdb.Name,
 		Namespace: pdb.Namespace,

--- a/controllers/zookeepercluster_controller_test.go
+++ b/controllers/zookeepercluster_controller_test.go
@@ -16,18 +16,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pravega/zookeeper-operator/api/v1beta1"
-	"github.com/pravega/zookeeper-operator/pkg/controller/config"
-	"github.com/pravega/zookeeper-operator/pkg/zk"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/pravega/zookeeper-operator/api/v1beta1"
+	"github.com/pravega/zookeeper-operator/pkg/controller/config"
+	"github.com/pravega/zookeeper-operator/pkg/zk"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -185,7 +186,7 @@ var _ = Describe("ZookeeperCluster Controller", func() {
 			})
 
 			It("should create a pdb", func() {
-				foundPdb := &policyv1beta1.PodDisruptionBudget{}
+				foundPdb := &policyv1.PodDisruptionBudget{}
 				err = cl.Get(context.TODO(), req.NamespacedName, foundPdb)
 				Ω(err).To(BeNil())
 			})

--- a/pkg/zk/generators.go
+++ b/pkg/zk/generators.go
@@ -16,12 +16,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pravega/zookeeper-operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/pravega/zookeeper-operator/api/v1beta1"
 )
 
 const (
@@ -352,19 +353,19 @@ func makeService(name string, ports []v1.ServicePort, clusterIP bool, external b
 }
 
 // MakePodDisruptionBudget returns a pdb for the zookeeper cluster
-func MakePodDisruptionBudget(z *v1beta1.ZookeeperCluster) *policyv1beta1.PodDisruptionBudget {
+func MakePodDisruptionBudget(z *v1beta1.ZookeeperCluster) *policyv1.PodDisruptionBudget {
 	pdbCount := intstr.FromInt(int(z.Spec.MaxUnavailableReplicas))
-	return &policyv1beta1.PodDisruptionBudget{
+	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
-			APIVersion: "policy/v1beta1",
+			APIVersion: "policy/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      z.GetName(),
 			Namespace: z.Namespace,
 			Labels:    z.Spec.Labels,
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			MaxUnavailable: &pdbCount,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{

--- a/pkg/zk/generators_test.go
+++ b/pkg/zk/generators_test.go
@@ -12,18 +12,18 @@ package zk_test
 
 import (
 	"fmt"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
+	policyv1 "k8s.io/api/policy/v1"
 
-	"strings"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/pravega/zookeeper-operator/api/v1beta1"
 	"github.com/pravega/zookeeper-operator/pkg/utils"
 	"github.com/pravega/zookeeper-operator/pkg/zk"
-	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -560,7 +560,7 @@ var _ = Describe("Generators Spec", func() {
 	})
 
 	Context("#MakePodDisruptionBudget", func() {
-		var pdb *policyv1beta1.PodDisruptionBudget
+		var pdb *policyv1.PodDisruptionBudget
 		var domainName string
 		var zkClusterName string
 


### PR DESCRIPTION
### Change log description
Replaces the deprecated PodDistruptionBudget policy/v1beta1 API with the new policy/v1 API.

### Purpose of the change

Closes https://github.com/pravega/zookeeper-operator/issues/428

### What the code does

Replaces the policy/v1beta1 API by simply changing the API version, there are no schema changes to the API, only a behavioral change - see https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125.

### How to verify it

A simple verification would be to manually create a ZK cluster on a 1.25 Kubernetes cluster and verify that the PDB created is using the new API. The e2e tests seem to cover this though so those seem to be sufficient. 
