### PR TITLE
Run Zookeeper container with user 'zookeeper' instead of 'root'

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,3 +22,5 @@ COPY --from=0 /zu/build/libs/zu.jar /opt/libs/
 
 RUN apt-get -q update && \
     apt-get install -y dnsutils curl procps socat
+
+USER zookeeper

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,10 +17,11 @@ RUN ./gradlew --console=verbose --info shadowJar
 
 FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}zookeeper:3.7.1
 COPY bin /usr/local/bin
-RUN chmod +x /usr/local/bin/*
 COPY --from=0 /zu/build/libs/zu.jar /opt/libs/
 
 RUN apt-get -q update && \
+    chmod +x /usr/local/bin/* && \
+    chown zookeeper:zookeeper /usr/local/bin/* /opt/libs/* && \
     apt-get install -y dnsutils curl procps socat
 
 USER zookeeper


### PR DESCRIPTION
### Change log description

Makes Zookeeper container run as user `zookeeper` instead of as 'root'

### Purpose of the change

Fixes #538

### What the code does

Changes user in Dockerfile

### How to verify it

Build the image and run Zookeeper. Verify that it runs as user `zookeeper`.

**TODO:** The zookeeper POD needs `fsGroup: 1000` for this to work, so the mounted data PVC with be owned by the `zookeeper` group.