### PR TITLE
the default snapCount configuration doesn't mismatch the comment.

### DIFF
--- a/api/v1beta1/zookeepercluster_types.go
+++ b/api/v1beta1/zookeepercluster_types.go
@@ -697,7 +697,7 @@ func (c *ZookeeperConfig) withDefaults() (changed bool) {
 	}
 	if c.SnapCount == 0 {
 		changed = true
-		c.SnapCount = 10000
+		c.SnapCount = 100000
 	}
 	if c.CommitLogCount == 0 {
 		changed = true


### PR DESCRIPTION

### Change log description

The default value of `snapCount` that the comment says is 100,000. 
But the actual value is set at 10,000.
I corrected this mismatch between them.


### Purpose of the change

None

### What the code does



### How to verify it


