### PR TITLE
Issue 585: Upgrade Zookeeper to version 3.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The project is currently alpha. While no breaking API changes are currently plan
 
 ### Overview
 
-This operator runs a Zookeeper 3.7.1 cluster, and uses Zookeeper dynamic reconfiguration to handle node membership.
+This operator runs a Zookeeper 3.7.2 cluster, and uses Zookeeper dynamic reconfiguration to handle node membership.
 
 The operator itself is built with the [Operator framework](https://github.com/operator-framework/operator-sdk).
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ COPY zu /zu
 WORKDIR /zu
 RUN ./gradlew --console=verbose --info shadowJar
 
-FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}zookeeper:3.7.1
+FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}zookeeper:3.7.2
 COPY bin /usr/local/bin
 RUN chmod +x /usr/local/bin/*
 COPY --from=0 /zu/build/libs/zu.jar /opt/libs/

--- a/docker/zu/build.gradle.kts
+++ b/docker/zu/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    implementation("org.apache.zookeeper:zookeeper:3.7.1")
+    implementation("org.apache.zookeeper:zookeeper:3.7.2")
 }
 
 tasks.withType<ShadowJar>() {


### PR DESCRIPTION
### Change log description

While running trivy to look for vulnerabilities in the latest 0.2.15 images, the report returned multiple CRITICAL CVEs in the zookeeper image that have been resolved in the latest stable 3.7.2.

### Purpose of the change

Fixes #585.

### What the code does

Upgrade version of Zookeeper to version 3.7.2

### How to verify it

> Build validation
make build-zk-image runs succesfully

> Tests executed
ran `make test`
```
go test $(go list ./... | grep -v /vendor/ | grep -v /test/e2e) -race -coverprofile=coverage.txt -covermode=atomic
?   	github.com/pravega/zookeeper-operator	[no test files]
?   	github.com/pravega/zookeeper-operator/cmd/exporter	[no test files]
?   	github.com/pravega/zookeeper-operator/pkg/controller/config	[no test files]
?   	github.com/pravega/zookeeper-operator/pkg/version	[no test files]
ok  	github.com/pravega/zookeeper-operator/api/v1beta1	1.421s	coverage: 99.0% of statements
ok  	github.com/pravega/zookeeper-operator/controllers	15.710s	coverage: 78.3% of statements
ok  	github.com/pravega/zookeeper-operator/pkg/utils	1.135s	coverage: 68.6% of statements
ok  	github.com/pravega/zookeeper-operator/pkg/yamlexporter	1.093s	coverage: 72.2% of statements
ok  	github.com/pravega/zookeeper-operator/pkg/zk	6.184s	coverage: 96.2% of statements

```
ran `make test-e2e-remote
```
make test-e2e-remote
Ran 8 of 8 Specs in 3362.154 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAPIs (3362.16s)
PASS

```

> Integration tests
Build my solution with the zookeeper-operator image.