### PR TITLE
issue-589-Added imagepullsecrets for both helm hooks in zk-operator charts

### DIFF
--- a/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
+++ b/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
@@ -51,6 +51,12 @@ metadata:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+{{- if or .Values.global.imagePullSecrets .Values.hooks.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+{{- range (default .Values.global.imagePullSecrets .Values.hooks.serviceAccount.imagePullSecrets) }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 
 ---
 

--- a/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
+++ b/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
@@ -45,6 +45,12 @@ metadata:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+{{- if or .Values.global.imagePullSecrets .Values.hooks.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+{{- range (default .Values.global.imagePullSecrets .Values.hooks.serviceAccount.imagePullSecrets) }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 
 ---
 

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -57,6 +57,11 @@ tolerations: []
 annotations: {}
 
 hooks:
+  ## Optionally specify an array of imagePullSecrets. Will override the global parameter if set
+  serviceAccount:
+    imagePullSecrets: []
+  # - private-registry-key
+
   backoffLimit: 10
   image:
     repository: lachlanevenson/k8s-kubectl


### PR DESCRIPTION
### Change log description

Currently the helm hooks used in zookeeper operator doesn't provide a mechanism to add imagepullsecrets to pull images from private registry.
The PR could help us to override this limitation.

### Purpose of the change

Fixes #589 

### What the code does

The code snippet will render the imagepull secrets added in either global section OR under hooks.serviceAccount.imagePullSecrets in values file.

### How to verify it

```bash
## Create a secret in the desired namespace
kubectl create secret docker-registry  registry-name --docker-username=<username> --docker-password=<password> --namespace=zk-operator
helm upgrade --install zk <chartPath> -n zk-operator --create-namespace --set hooks.serviceAccount.imagePullSecrets={'registry-name'} --set global.imagePullSecrets={'registry-name'} --atomic

## OR

helm template zookeeper . -s templates/post-install-upgrade-hooks.yaml --namespace=zk-operator --set hooks.serviceAccount.imagePullSecrets={'regsitry-name'}
helm template zookeeper . -s templates/pre-delete-hooks.yaml --namespace=zk-operator --set hooks.serviceAccount.imagePullSecrets={'regsitry-name'}


```

