### PR TITLE
Issue 589: Add imagePullSecrets for Helm hooks

### DIFF
--- a/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
+++ b/charts/zookeeper-operator/templates/post-install-upgrade-hooks.yaml
@@ -51,6 +51,12 @@ metadata:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+{{- if or .Values.global.imagePullSecrets .Values.hooks.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+{{- range (default .Values.global.imagePullSecrets .Values.hooks.serviceAccount.imagePullSecrets) }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 
 ---
 

--- a/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
+++ b/charts/zookeeper-operator/templates/pre-delete-hooks.yaml
@@ -45,6 +45,12 @@ metadata:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
+{{- if or .Values.global.imagePullSecrets .Values.hooks.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+{{- range (default .Values.global.imagePullSecrets .Values.hooks.serviceAccount.imagePullSecrets) }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 
 ---
 

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -57,6 +57,10 @@ tolerations: []
 annotations: {}
 
 hooks:
+  ## Optionally specify an array of imagePullSecrets. Will override the global parameter if set
+  serviceAccount:
+    imagePullSecrets: []
+
   backoffLimit: 10
   image:
     repository: lachlanevenson/k8s-kubectl


### PR DESCRIPTION
### Change log description

* Adds imagePullSecrets to the service accounts for the Helm hooks
* Follows the same principle as the service account for the operator taking global imagePullSecrets into account

### Purpose of the change

Fixes #589

### What the code does

Adds imagePullSecrets to the YAML for the ServiceAccounts for the Helm hooks. This is important when images are pulled from a private registry, e.g. an internal proxy, such as Artifactory, or when using custom images.

### How to verify it

Render the templates using the following command:

```console
helm template zookeeper charts/zookeeper-operator \
    --show-only templates/post-install-upgrade-hooks.yaml \
    --show-only templates/pre-delete-hooks.yaml \
    --set hooks.serviceAccount.imagePullSecrets={'my-pull-secret'}
```
