### PR TITLE
ci: migrate to `actions/checkout@v4`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
     - name: Pushing docker images
       run: sudo make push
     - name: Uploading binary files
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: zookeeper-exporter
         path: bin/zookeeper-exporter*


### PR DESCRIPTION
### Change log description

See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions

### Purpose of the change

_(e.g., Fixes #666, Closes #1234)_

### What the code does

_(Detailed description of the code changes)_

### How to verify it

_(Steps to verify that the changes are effective)_
