### PR TITLE
Issue 623: add security context override to operator deployment (#623)

### DIFF
--- a/charts/zookeeper-operator/README.md
+++ b/charts/zookeeper-operator/README.md
@@ -58,8 +58,10 @@ The following table lists the configurable parameters of the zookeeper-operator 
 | `image.tag` | Image tag | `0.2.15` |
 | `labels` | Operator pod labels | `{}` |
 | `nodeSelector` | Map of key-value pairs to be present as labels in the node in which the pod should run | `{}` |
+| `podSecurityContext` | Security context for the pod | `{}` |
 | `rbac.create` | Create RBAC resources | `true` |
 | `resources` | Specifies resource requirements for the container | `{}` |
+| `securityContext` | Security context for the container | `{}` |
 | `serviceAccount.create` | Create service account | `true` |
 | `serviceAccount.name` | Name for the service account | `zookeeper-operator` |
 | `tolerations` | Specifies the pod's tolerations | `[]` |

--- a/charts/zookeeper-operator/templates/operator.yaml
+++ b/charts/zookeeper-operator/templates/operator.yaml
@@ -24,6 +24,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+      {{- end }}
       {{- if .Values.additionalVolumes }}
       volumes:
 {{- include "chart.additionalVolumes" . | indent 6 }}
@@ -32,6 +36,10 @@ spec:
       - name: {{ template "zookeeper-operator.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.securityContext }}
+        securityContext:
+{{ toYaml .Values.securityContext | indent 10 }}
+        {{- end }}
         ports:
         - containerPort: {{ int .Values.metricsPort }}
           name: metrics

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -13,8 +13,15 @@ image:
   pullPolicy: IfNotPresent
 
 securityContext: {}
+#  allowPrivilegeEscalation: false
+#  capabilities:
+#    drop:
+#    - ALL
+
+podSecurityContext: {}
 #  runAsUser: 1001
 #  runAsGroup: 1001
+#  fsGroup: 1001
 
 ## Additional labels to be added to resources
 labels: {}


### PR DESCRIPTION
### Change log description

* Add podSecurityContext and securityContext overrides to Zookeeper Operator deployment in helm chart
* Updated README for helm chart

### Purpose of the change

Fixes #623 

### What the code does

Updated the Zookeper Operator helm chart to include the already existing securityContext section in the helm chart values.yaml file. Now, the securityContext values are correctly added to the operator Deployment. This ensures that the operator can run in a Kubernetes cluster where Pod Security Admission is enforced, and running in restricted mode.

### How to verify it

Add custom settings to securityContext and/or podSecurityContext, and verify that the deployment object has been updated using: `kubectl -n <namespace> describe deployment zookeeper-operator`
